### PR TITLE
Secure stuff behind login_required

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -323,10 +323,10 @@ PLOTLY_COMPONENTS = [
 
 PLOTLY_DASH = {
     "ws_route": "ws/channel",
-    "insert_demo_migrations":True,  # Insert model instances used by the demo
-    "http_poke_enabled":True, # Flag controlling availability of direct-to-messaging http endpoint
-    "view_decorator":None, # Specify a function to be used to wrap each of the dpd view functions
-    "cache_arguments":True, # True for cache, False for session-based argument propagation
+    "insert_demo_migrations": True,  # Insert model instances used by the demo
+    "http_poke_enabled": True, # Flag controlling availability of direct-to-messaging http endpoint
+    "cache_arguments": True, # True for cache, False for session-based argument propagation
     #"serve_locally":True, # True to serve assets locally, False to use their unadulterated urls (eg a CDN)
-    "stateless_loader":"demo.scaffold.stateless_app_loader"
-    }
+    "stateless_loader": "demo.scaffold.stateless_app_loader",
+    "view_decorator": "django_plotly_dash.access.login_required",
+}

--- a/va_explorer/templates/partials/_top_navigation.html
+++ b/va_explorer/templates/partials/_top_navigation.html
@@ -17,13 +17,14 @@
         <a class="{% active '\/(.*)users' %} nav-link" href="{% url 'users:index' %}">Users</a>
       </li>
       {% endif %}
-      {% comment "TODO: These features will only be available to logged in users" %}{% endcomment %}
-      <li class="nav-item">
-        <a class="{% active '\/(.*)dashboard' %} nav-link" href="{% url 'va_analytics:dashboard' %}">Dashboard</a>
-      </li>
-      <li class="nav-item">
-        <a class="{% active '\/(.*)data_management' %} nav-link" href="{% url 'va_data_management:index' %}">Data Management</a>
-      </li>
+      {% if request.user.is_authenticated %}
+        <li class="nav-item">
+          <a class="{% active '\/(.*)dashboard' %} nav-link" href="{% url 'va_analytics:dashboard' %}">Dashboard</a>
+        </li>
+        <li class="nav-item">
+          <a class="{% active '\/(.*)data_management' %} nav-link" href="{% url 'va_data_management:index' %}">Data Management</a>
+        </li>
+      {% endif %}
     </ul>
     <ul class="navbar-nav ml-auto my-2 my-lg-0">
       {% if request.user.is_authenticated %}

--- a/va_explorer/va_analytics/views.py
+++ b/va_explorer/va_analytics/views.py
@@ -1,15 +1,20 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.decorators import login_required
 from django.views.generic import TemplateView
 from django.http import HttpResponse
 import pandas as pd
 from django.forms.models import model_to_dict
 from va_explorer.va_data_management.models import Location, VerbalAutopsy
 
-class DashboardView(TemplateView):
+
+class DashboardView(LoginRequiredMixin, TemplateView):
     template_name = "va_analytics/dashboard.html"
 
 
 dashboard_view = DashboardView.as_view()
 
+
+@login_required
 def download_csv(request, out_file="va_download.csv"):
 
     # pull in va records with CODs from database 

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -1,7 +1,9 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
 from .models import VerbalAutopsy, CauseOfDeath, CauseCodingIssue, Location
 from .forms import VerbalAutopsyForm
 
+@login_required
 def index(request):
     va_list = VerbalAutopsy.objects.prefetch_related("location", "causes", "coding_issues").order_by("id")
     va_data = [{
@@ -18,6 +20,7 @@ def index(request):
 # TODO: Use standard django CRUD conventions; e.g. see https://stackoverflow.com/questions/4673985/how-to-update-an-object-from-edit-form-in-django
 
 # TODO: Is the convention to use pk instead of id in django?
+@login_required
 def show(request, id):
     va = VerbalAutopsy.objects.get(id=id)
     form = VerbalAutopsyForm(None, instance=va)
@@ -32,6 +35,7 @@ def show(request, id):
     context = { "id": id, "form": form, "warnings": warnings, "errors": errors, "diffs": diffs }
     return render(request, "va_data_management/show.html", context)
 
+@login_required
 def edit(request, id):
     # TODO: We only want to allow editing of some fields
     # TODO: We want to provide context for all the fields
@@ -41,6 +45,7 @@ def edit(request, id):
     context = { "id": id, "form": form }
     return render(request, "va_data_management/edit.html", context)
 
+@login_required
 def save(request, id):
     # TODO: There are probably more appropriate ways to handle form editing in django
     # TODO: When a record is changed, should it automatically be recoded if it was already coded?
@@ -52,6 +57,7 @@ def save(request, id):
 
 # Reset to the first historical record
 # TODO: If a record is reset, should it automatically be recoded?
+@login_required
 def reset(request, id):
     va = VerbalAutopsy.objects.get(id=id)
     earliest = va.history.earliest()
@@ -62,6 +68,7 @@ def reset(request, id):
 
 # Revert the most recent change
 # TODO: Should record automatically be recoded?
+@login_required
 def revert_latest(request, id):
     va = VerbalAutopsy.objects.get(id=id)
     if va.history.count() > 1:


### PR DESCRIPTION
Secures pages behind a login_required decorator or LoginRequiredMixin.

The plotly dash views have a separate way of applying the decorator:
https://django-plotly-dash.readthedocs.io/en/latest/access_control.html

Removes Dashboard and Data Management from header unless you're logged in.