### PR TITLE
Add bootstrap4 to base installed_apps to fix tests.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -71,7 +71,8 @@ THIRD_PARTY_APPS = [
     "django_celery_beat",
     "django_plotly_dash.apps.DjangoPlotlyDashConfig",
     "simple_history",
-    "channels"
+    "channels",
+    "bootstrap4",
 ]
 
 LOCAL_APPS = [

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -57,9 +57,6 @@ if env("USE_DOCKER") == "yes":
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
     INTERNAL_IPS += [".".join(ip.split(".")[:-1] + ["1"]) for ip in ips]
 
-# django-bootstrap4
-# ------------------------------------------------------------------------------
-INSTALLED_APPS += ['bootstrap4']
 # django-extensions
 # ------------------------------------------------------------------------------
 # https://django-extensions.readthedocs.io/en/latest/installation_instructions.html#configuration


### PR DESCRIPTION
I think the issue was that `bootstrap4` was only defined in local settings. This means that it wasn't loading properly in tests.

It was causing the `{% bootstrap4 %}` template tag to fail and causing a bunch of cascading errors.

I moved it to base settings (which is inherited by test, local, and prod settings) and it fixed it for me.