### PR TITLE
Remove unused ready method that imports nonexistent user signal.

### DIFF
--- a/va_explorer/users/apps.py
+++ b/va_explorer/users/apps.py
@@ -5,9 +5,3 @@ from django.utils.translation import gettext_lazy as _
 class UsersConfig(AppConfig):
     name = "va_explorer.users"
     verbose_name = _("Users")
-
-    def ready(self):
-        try:
-            import va_explorer.users.signals  # noqa F401
-        except ImportError:
-            pass


### PR DESCRIPTION
Remove unused ready method in apps.py that imports nonexistent user signal. Issue identified in VA Explorer Security review on 1/13/2021.