### PR TITLE
Fix issues with messages on login screen.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -84,6 +84,7 @@ AUTHENTICATION_BACKENDS = [
 AUTH_USER_MODEL = "users.User"
 LOGIN_REDIRECT_URL = "users:redirect"
 LOGIN_URL = "account_login"
+ACCOUNT_LOGOUT_REDIRECT_URL = "account_login"
 
 # Passwords
 

--- a/va_explorer/templates/account/login.html
+++ b/va_explorer/templates/account/login.html
@@ -55,5 +55,8 @@
 
 {% endblock %}
 
+  <script src="{% static 'vendor/jquery-3.5.1/jquery.js' %}"></script>
+  <script src="{% static 'vendor/bootstrap-4.3.1/bootstrap.js' %}"></script>
+
   </body>
 </html>


### PR DESCRIPTION
Adds Bootstrap JavaScript to the login page so that the messages can be dismissed.

Changes the `ACCOUNT_LOGOUT_REDIRECT_URL` setting to the login page. If it's set as the main page, you get unintuitive messages after logging out (one for having logged out, and one for trying to access the homepage which requires you to login):

<img width="1366" alt="Capture 2021-02-15 at 3 28 51 PM" src="https://user-images.githubusercontent.com/173666/107990596-bbbc5880-6fa2-11eb-9708-663d327cb9c7.png">

With the change, only the "You have signed out" message will appear.
