### PR TITLE
Remove join and conditions in get_help_text

### DIFF
--- a/va_explorer/users/validators.py
+++ b/va_explorer/users/validators.py
@@ -56,30 +56,7 @@ class PasswordComplexityValidator:
             raise ValidationError(validation_errors)
 
     def get_help_text(self):
-        validation_reqs = []
-        if self.password_no_number:
-            validation_reqs.append(_("Password requires at least one number"))
-        if self.password_no_uppercase:
-            validation_reqs.append(
-                _(
-                    "Password requires at least one uppercase letter from Latin alphabet (A–Z)"
-                )
-            )
-        if self.password_no_lowercase:
-            validation_reqs.append(
-                _(
-                    "Password requires at least one lowercase letter from Latin alphabet (a-z)"
-                )
-            )
-        if self.password_no_special:
-            validation_reqs.append(
-                _(
-                    "Password requires at least one nonalphanumeric character ! @ # $ % ^ & * ( ) _ + - = [ ] { } | '"
-                )
-            )
-        return _("Password does not meet complexity requirements:\n").join(
-            validation_reqs
-        )
+        return _("Your password requires at least one number, one lowercase letter, one uppercase letter, and one nonalphanumeric character ! @ # $ % ^ & * ( ) _ + - = [ ] { } | '")
 
 
 class PasswordHistoryValidator:


### PR DESCRIPTION
This PR addresses 2 tickets: "Exception on validation error in set password"  and "User password requirements displayed incorrectly in view on set password. There is a an empty bullet and all of the requirements aren't listed."  

The crash was caused in get_help_text by trying to join translation strings that used gettext_lazy. These have type __proxy__ not str and caused the error. 
The complexity validator's get_help_text was implemented as if it were the conditional feedback warnings, but should return a consistent string to be displayed in the bulleted list. The conditions were removed and the requirements were combined into one single line. This meant there was no need to call join, so this fix addressed the issues in both tickets.

Testing
- On the set password and change password pages, the empty bullet should show the complexity requirements
- Enter a password that does not meet multiple requirements, make sure the requirements appear in red 
- Enter a password that does not meet 1 requirement, make sure the requirement appears in red
- Enter a valid password, should result in success message