### PR TITLE
Scope verbal autopsies based on user location restrictions

### DIFF
--- a/va_explorer/templates/va_data_management/show.html
+++ b/va_explorer/templates/va_data_management/show.html
@@ -99,7 +99,7 @@
             {% for diff in diffs %}
               <tr>
                 <td>{{ diff.new_record.history_date|date:"Y-m-d H:i" }}</td>
-                <td>{{ diff.new_record.history_user.name }}</td>
+                <td>{{ diff.new_record.history_user.name }} &lt;{{ diff.new_record.history_user.email }}&gt;</td>
                 <td>
                   {% for change in diff.changes %}
                     {% if change.old and change.new %}

--- a/va_explorer/tests/factories.py
+++ b/va_explorer/tests/factories.py
@@ -34,11 +34,12 @@ class LocationFactory(DjangoModelFactory):
     class Meta:
         model = Location
 
+    # Create a root node by default
     name = Faker("city")
-    depth = FuzzyInteger(0, 4, 1)
-    location_type = "district"
-    numchild = FuzzyInteger(0, 20)
-    path = "001"
+    depth = 1
+    numchild = 0
+    location_type = "province"
+    path = "0001"
 
 class VerbalAutopsyFactory(DjangoModelFactory):
     class Meta:
@@ -67,15 +68,15 @@ class UserFactory(DjangoModelFactory):
                 self.groups.add(group)
 
     @factory.post_generation
-    def locations(self, create, extracted, *kwargs):
+    def location_restrictions(self, create, extracted, *kwargs):
         if not create:
             # Simple build, do nothing.
             return
 
         if extracted:
-            # A list of groups were passed in, use them
+            # A list of locations were passed in, use them
             for location in extracted:
-                self.locations.add(location)
+                self.location_restrictions.add(location)
 
 
 class NewUserFactory(UserFactory):

--- a/va_explorer/users/tests/test_models.py
+++ b/va_explorer/users/tests/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 
 from va_explorer.users.models import User, UserPasswordHistory
-from va_explorer.tests.factories import UserFactory
+from va_explorer.tests.factories import UserFactory, LocationFactory, VerbalAutopsyFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -17,3 +17,40 @@ def test_user_password_history_exists():
 
     password_history = UserPasswordHistory.objects.filter(user_id=user)
     assert password_history.count() == 1
+
+def test_user_scoped_verbal_autopsies():
+    # Set up a small tree of locations; top level province, two districts, three facilities
+    province = LocationFactory.create()
+    district1 = province.add_child(name='District1', location_type='district')
+    facility1 = district1.add_child(name='Facility1', location_type='facility')
+    district2 = province.add_child(name='District2', location_type='district')
+    facility2 = district2.add_child(name='Facility2', location_type='facility')
+    facility3 = district2.add_child(name='Facility3', location_type='facility')
+    # Each facility with one VA
+    va1 = VerbalAutopsyFactory.create(location=facility1)
+    va2 = VerbalAutopsyFactory.create(location=facility2)
+    va3 = VerbalAutopsyFactory.create(location=facility3)
+    # A user with no location restrictions should see all VAs in the system
+    user = UserFactory.create()
+    assert user.verbal_autopsies().count() == 3
+    # A user restricted to the province should see all VAs
+    user = UserFactory.create(location_restrictions=[province])
+    assert user.verbal_autopsies().count() == 3
+    # A user restricted to a district should see the correct subset of VAs
+    user = UserFactory.create(location_restrictions=[district1])
+    assert user.verbal_autopsies().count() == 1
+    assert va1 in user.verbal_autopsies()
+    user = UserFactory.create(location_restrictions=[district2])
+    assert user.verbal_autopsies().count() == 2
+    assert va2 in user.verbal_autopsies()
+    assert va3 in user.verbal_autopsies()
+    # A user restricted to a facility should see the correct VA
+    user = UserFactory.create(location_restrictions=[facility1])
+    assert user.verbal_autopsies().count() == 1
+    assert va1 in user.verbal_autopsies()
+    user = UserFactory.create(location_restrictions=[facility2])
+    assert user.verbal_autopsies().count() == 1
+    assert va2 in user.verbal_autopsies()
+    user = UserFactory.create(location_restrictions=[facility3])
+    assert user.verbal_autopsies().count() == 1
+    assert va3 in user.verbal_autopsies()

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -64,7 +64,6 @@ class Show(CustomAuthMixin, DetailView, AccessRestrictionMixin):
         context['errors'] = [issue for issue in coding_issues if issue.severity == 'error']
 
         # TODO: date in diff info should be formatted in local time
-        # TODO: history should eventually show user who made the change
         history = self.object.history.all().reverse()
         history_pairs = zip(history, history[1:])
         context['diffs'] = [new.diff_against(old) for (old, new) in history_pairs]


### PR DESCRIPTION
This pull request

1) Adds a `verbal_autopsies` helper method on the user model that returns just the verbal autopsies the user can access based on their location restrictions (if any)

2) Adds tests for the `verbal_autopsies` helper method

3) Implements location-scoped access control for the verbal autopsy data management functions (viewing, editing, etc)

4) Adds tests for data management access control

5) Incidentally adds the email address of the user making the change to the verbal autopsy change history

Note that this pull request only partially implements location-scoping as needed in the application; for example, it

* Addresses https://www.pivotaltracker.com/story/show/176873370

* Partially addresses https://www.pivotaltracker.com/story/show/176870340, https://www.pivotaltracker.com/story/show/176870399, and https://www.pivotaltracker.com/story/show/176870423

* Does not address https://www.pivotaltracker.com/story/show/176869720