### PR TITLE
Restrict fw dv permissions

### DIFF
--- a/fixtures/group.json
+++ b/fixtures/group.json
@@ -1,1 +1,88 @@
-[{"model": "auth.group", "fields": {"name": "Admins", "permissions": [["add_user", "users", "user"], ["change_user", "users", "user"], ["delete_user", "users", "user"], ["view_user", "users", "user"]]}}, {"model": "auth.group", "fields": {"name": "Data Managers", "permissions": [["add_user", "users", "user"], ["change_user", "users", "user"], ["delete_user", "users", "user"], ["view_user", "users", "user"]]}}, {"model": "auth.group", "fields": {"name": "Data Viewers", "permissions": [["view_user", "users", "user"]]}}, {"model": "auth.group", "fields": {"name": "Field Workers", "permissions": []}}]
+[
+    {
+        "model": "auth.group",
+        "fields": {
+            "name": "Admins",
+            "permissions": [
+                [
+                    "add_user",
+                    "users",
+                    "user"
+                ],
+                [
+                    "change_user",
+                    "users",
+                    "user"
+                ],
+                [
+                    "delete_user",
+                    "users",
+                    "user"
+                ],
+                [
+                    "view_user",
+                    "users",
+                    "user"
+                ],
+                [
+                    "change_verbalautopsy",
+                    "va_data_management",
+                    "verbalautopsy"
+                ]
+            ]
+        }
+    },
+    {
+        "model": "auth.group",
+        "fields": {
+            "name": "Data Managers",
+            "permissions": [
+                [
+                    "add_user",
+                    "users",
+                    "user"
+                ],
+                [
+                    "change_user",
+                    "users",
+                    "user"
+                ],
+                [
+                    "delete_user",
+                    "users",
+                    "user"
+                ],
+                [
+                    "view_user",
+                    "users",
+                    "user"
+                ],
+                [
+                    "change_verbalautopsy",
+                    "va_data_management",
+                    "verbalautopsy"
+                ]
+            ]
+        }
+    },
+    {
+        "model": "auth.group",
+        "fields": {
+            "name": "Data Viewers",
+            "permissions": [
+                [
+                    "view_user",
+                    "users",
+                    "user"
+                ]
+            ]
+        }
+    },
+    {
+        "model": "auth.group",
+        "fields": {
+            "name": "Field Workers",
+            "permissions": []
+        }
+    }
+]

--- a/va_explorer/templates/va_data_management/show.html
+++ b/va_explorer/templates/va_data_management/show.html
@@ -118,9 +118,11 @@
         </table>
       </div>
       <div class="row mt-4">
+        {% if perms.va_data_management.change_verbalautopsy %}
         <!-- TODO: these should be buttons in forms and making a POST request instead of GET -->
         <a class="btn btn-primary mx-2" href="{% url 'data_management:reset' id=id %}">Reset to Original</a></p>
         <a class="btn btn-primary mx-2" href="{% url 'data_management:revert_latest' id=id %}">Revert Most Recent Change</a>
+        {% endif %}
       </div>
     </div>
 

--- a/va_explorer/templates/va_data_management/show.html
+++ b/va_explorer/templates/va_data_management/show.html
@@ -24,7 +24,9 @@
 <div class="tab-content">
   <div class="tab-pane fade show active" id="record" role="tabpanel" aria-labelledby="record-tab">
     <div class="row mt-3">
-      <a class="btn btn-primary" href="{% url 'data_management:edit' id=id %}">Edit Record</a>
+      {% if perms.va_data_management.change_verbalautopsy %}
+        <a class="btn btn-primary" href="{% url 'data_management:edit' id=id %}">Edit Record</a>
+      {% endif %}
     </div>
 
     <div class="row mt-4">

--- a/va_explorer/users/management/commands/initialize_groups.py
+++ b/va_explorer/users/management/commands/initialize_groups.py
@@ -2,15 +2,16 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.core.management import BaseCommand
 
+from va_explorer.va_data_management.models import VerbalAutopsy 
+
 User = get_user_model()
 
 GROUPS_PERMISSIONS = {
-    "Admins": {User: ["add", "change", "delete", "view"]},
-    "Data Managers": {User: ["add", "change", "delete", "view"]},
+    "Admins": {User: ["add", "change", "delete", "view"], VerbalAutopsy: ["change"]},
+    "Data Managers": {User: ["add", "change","delete", "view"], VerbalAutopsy: ["change"]},
     "Data Viewers": {User: ["view"]},
     "Field Workers": {User: []},
 }
-
 
 class Command(BaseCommand):
     def __init__(self, *args, **kwargs):

--- a/va_explorer/va_data_management/tests/test_views.py
+++ b/va_explorer/va_data_management/tests/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 from django.test import Client
+from django.contrib.auth.models import Permission
 from va_explorer.users.models import User
 from va_explorer.va_data_management.models import VerbalAutopsy
 from va_explorer.tests.factories import GroupFactory, VerbalAutopsyFactory, UserFactory
@@ -49,6 +50,10 @@ def test_edit_without_valid_permissions(user: User):
 
 # Update a VA and make sure 1) the data is changed and 2) the history is tracked
 def test_save(user: User):
+    can_edit_record = Permission.objects.filter(codename="change_verbalautopsy").first()
+    can_edit_record_group = GroupFactory.create(permissions=[can_edit_record])
+    user = UserFactory.create(groups=[can_edit_record_group])
+
     client = Client()
     client.force_login(user=user)
     va = VerbalAutopsyFactory.create()
@@ -68,6 +73,10 @@ def test_save(user: User):
 
 # Reset an updated VA and make sure 1) the data is reset to original values and 2) the history is tracked
 def test_reset(user: User):
+    can_edit_record = Permission.objects.filter(codename="change_verbalautopsy").first()
+    can_edit_record_group = GroupFactory.create(permissions=[can_edit_record])
+    user = UserFactory.create(groups=[can_edit_record_group])
+
     client = Client()
     client.force_login(user=user)
     va = VerbalAutopsyFactory.create()
@@ -88,6 +97,10 @@ def test_reset(user: User):
 
 # Revert an updated VA and make sure 1) the data is reset to previous version and 2) the history is tracked
 def test_revert_latest(user: User):
+    can_edit_record = Permission.objects.filter(codename="change_verbalautopsy").first()
+    can_edit_record_group = GroupFactory.create(permissions=[can_edit_record])
+    user = UserFactory.create(groups=[can_edit_record_group])
+
     client = Client()
     client.force_login(user=user)
     va = VerbalAutopsyFactory.create()

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.generic import TemplateView, DetailView, UpdateView, ListView
@@ -68,8 +69,9 @@ class Show(CustomAuthMixin, DetailView):
         return context
 
 
-class Edit(CustomAuthMixin, SuccessMessageMixin, UpdateView):
+class Edit(CustomAuthMixin, PermissionRequiredMixin, SuccessMessageMixin, UpdateView):
     template_name = 'va_data_management/edit.html'
+    permission_required = "va_data_management.change_verbalautopsy"
     form_class = VerbalAutopsyForm
     model = VerbalAutopsy
     pk_url_kwarg = 'id'

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -86,7 +86,8 @@ class Edit(CustomAuthMixin, PermissionRequiredMixin, SuccessMessageMixin, Update
         return context
 
 
-class Reset(CustomAuthMixin, DetailView):
+class Reset(CustomAuthMixin, PermissionRequiredMixin, DetailView):
+    permission_required = "va_data_management.change_verbalautopsy"
     model = VerbalAutopsy
     pk_url_kwarg = 'id'
     success_message = "Verbal Autopsy changes successfully reverted to original!"
@@ -100,7 +101,8 @@ class Reset(CustomAuthMixin, DetailView):
         return redirect('va_data_management:show', id=self.object.id)
 
 
-class RevertLatest(CustomAuthMixin, DetailView):
+class RevertLatest(CustomAuthMixin, PermissionRequiredMixin, DetailView):
+    permission_required = "va_data_management.change_verbalautopsy"
     model = VerbalAutopsy
     pk_url_kwarg = 'id'
     success_message = "Verbal Autopsy changes successfully reverted to previous!"


### PR DESCRIPTION
This PR is for ticket #176870613 "Data viewers/ Field workers have too many privileges" - editing VA records should be restricted to Data Managers and Admins.

Testing
- Run manage.py initialize_groups to add the new permissions
- Field Worker & Data Viewer users should not see the "Edit Record" button when viewing a record
- Field Worker & Data Viewer should get a 403 if they manually navigate to localhost:5000/va_data_management/edit/2
- Data Managers and Admins should still be able to edit records