### PR TITLE
Add metrics and actions to home page

### DIFF
--- a/va_explorer/home/tests/test_views.py
+++ b/va_explorer/home/tests/test_views.py
@@ -1,0 +1,38 @@
+import pytest
+from django.test import Client
+from va_explorer.users.models import User
+from va_explorer.va_data_management.models import VerbalAutopsy
+from va_explorer.tests.factories import VerbalAutopsyFactory, LocationFactory
+
+pytestmark = pytest.mark.django_db
+
+# Get the index and make sure 
+def test_index(user: User):
+    client = Client()
+    client.force_login(user=user)
+    va = VerbalAutopsyFactory.create()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.context['vas_collected_24_hours'] == 1
+    assert response.context['vas_collected_1_week'] == 1
+    assert response.context['vas_collected_1_month'] == 1
+    assert response.context['vas_collected_overall'] == 1
+    assert response.context['vas_coded_24_hours'] == 0
+    assert response.context['vas_coded_1_week'] == 0
+    assert response.context['vas_coded_1_month'] == 0
+    assert response.context['vas_coded_overall'] == 0
+    assert response.context['vas_uncoded_24_hours'] == 1
+    assert response.context['vas_uncoded_1_week'] == 1
+    assert response.context['vas_uncoded_1_month'] == 1
+    assert response.context['vas_uncoded_overall'] == 1
+    assert len(response.context['issue_list']) == 1
+    assert response.context['issue_list'][0]['name'] == va.Id10007
+    assert response.context['additional_issues'] == 0
+
+# Get the about page and make sure it returns successfully
+def test_about(user: User):
+    client = Client()
+    client.force_login(user=user)
+    va = VerbalAutopsyFactory.create()
+    response = client.get(f"/about/")
+    assert response.status_code == 200

--- a/va_explorer/home/urls.py
+++ b/va_explorer/home/urls.py
@@ -5,6 +5,6 @@ from . import views
 app_name = "home"
 
 urlpatterns = [
-    path("", view=views.index, name="index"),
-    path("about/", view=views.about, name="about"),
+    path("", view=views.Index.as_view(), name="index"),
+    path("about/", view=views.About.as_view(), name="about"),
 ]

--- a/va_explorer/home/views.py
+++ b/va_explorer/home/views.py
@@ -1,12 +1,102 @@
 from django.views.generic import TemplateView
-
+from django.db.models import Count
+from django.db.models.functions import TruncMonth
 from va_explorer.utils.mixins import CustomAuthMixin
+from datetime import date, timedelta
+from dateutil.relativedelta import relativedelta
+import numpy as np
 
+# TODO: We're using plotly here since it's already included in the project, but there may be slimmer options
+import plotly.offline as opy
+import plotly.graph_objs as go
+
+# Simple helper function for creating the plotly graphs used on the home page
+def graph(x, y):
+    figure = go.Figure(data=go.Scatter(x=x, y=y))
+    figure.update_layout(autosize=False, width=300, height=100, margin=dict(l=0, r=0, t=0, b=0, pad=0))
+    config = {'displayModeBar': False}
+    return opy.plot(figure, auto_open=False, output_type='div', config=config)
 
 class Index(CustomAuthMixin, TemplateView):
+
     template_name = "home/index.html"
 
+    def get_context_data(self, **kwargs):
+        # TODO: interviewers should only see their own data
+        context = super().get_context_data(**kwargs)
 
-index = Index.as_view()
+        user = self.request.user
+        user_vas = user.verbal_autopsies()
+        location_restrictions = user.location_restrictions
+        today = date.today()
 
-about = TemplateView.as_view(template_name="home/index.html")
+        if location_restrictions.count() > 0:
+            context['locations'] = ', '.join([location.name for location in location_restrictions.all()])
+        else:
+            context['locations'] = 'All Regions'
+
+        # Load the VAs that are collected over various periods of time
+        # TODO: We're using date imported, but might be more appropriate to use date collected? If updating
+        # this, look for all references to 'created'
+        vas_24_hours = user_vas.filter(created__gte=today)
+        vas_1_week = user_vas.filter(created__gte=today - timedelta(days=7))
+        vas_1_month = user_vas.filter(created__gte=today - relativedelta(months=1))
+        vas_overall = user_vas
+
+        # VAs collected in the past 24 hours, 1 week, and 1 month
+        context['vas_collected_24_hours'] = vas_24_hours.count()
+        context['vas_collected_1_week'] = vas_1_week.count()
+        context['vas_collected_1_month'] = vas_1_month.count()
+        context['vas_collected_overall'] = vas_overall.count()
+        # VAs successfully coded in the past 24 hours, 1 week, and 1 month
+        context['vas_coded_24_hours'] = vas_24_hours.filter(causes__isnull=False).count()
+        context['vas_coded_1_week'] = vas_1_week.filter(causes__isnull=False).count()
+        context['vas_coded_1_month'] = vas_1_month.filter(causes__isnull=False).count()
+        context['vas_coded_overall'] = vas_overall.filter(causes__isnull=False).count()
+        # VAs not able to be coded in the past 24 hours, 1 week, and 1 month
+        context['vas_uncoded_24_hours'] = context['vas_collected_24_hours'] - context['vas_coded_24_hours']
+        context['vas_uncoded_1_week'] = context['vas_collected_1_week'] - context['vas_coded_1_week']
+        context['vas_uncoded_1_month'] = context['vas_collected_1_month'] - context['vas_coded_1_month']
+        context['vas_uncoded_overall'] = context['vas_collected_overall'] - context['vas_coded_overall']
+
+        # Graphs of the past 12 months, not including this month (including the current month will almost
+        # always show the month with artificially low numbers)
+        start_month = date(today.year - 1, today.month, 1)
+        months = [start_month + relativedelta(months=i) for i in range(12)]
+        x = [month.strftime('%b') for month in months]
+
+        # Collected; this query groups by month (cast to a date from a datetime) and returns the counts by month
+        collected_counts = user_vas.filter(created__gte=start_month).annotate(month=TruncMonth('created')).values('month').annotate(count=Count('*'))
+        collected_by_month = {entry['month'].date():entry['count'] for entry in collected_counts}
+        y_collected = [collected_by_month.get(month, 0) for month in months]
+        context['graph_collected'] = graph(x, y_collected)
+
+        # Coded; same query as above, just filtered by whether the va has been coded
+        coded_counts = user_vas.filter(created__gte=start_month, causes__isnull=False).annotate(month=TruncMonth('created')).values('month').annotate(count=Count('*'))
+        coded_by_month = {entry['month'].date():entry['count'] for entry in coded_counts}
+        y_coded = [coded_by_month.get(month, 0) for month in months]
+        context['graph_coded'] = graph(x, y_coded)
+
+        # Uncoded; just take the difference between the two previous queries
+        context['graph_uncoded'] = graph(x, np.subtract(y_collected, y_coded))
+
+        # List the VAs that need attention; requesting certain fields and prefetching makes this more efficient
+        vas_to_address = vas_overall.only('id', 'location_id', 'Id10007', 'Id10023').filter(causes__isnull=True).prefetch_related("causes", "coding_issues", "location")[:10]
+        context['issue_list'] = [{
+            "id": va.id,
+            "name": va.Id10007,
+            "date": va.Id10023,
+            "facility": va.location.name,
+            "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
+            "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
+            "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
+        } for va in vas_to_address]
+
+        # If there are more than 10 show a link to where the rest can be seen
+        context['additional_issues'] = max(context['vas_uncoded_overall'] - 10, 0)
+
+        return context
+
+
+class About(CustomAuthMixin, TemplateView):
+    template_name = "home/about.html"

--- a/va_explorer/static/css/project.css
+++ b/va_explorer/static/css/project.css
@@ -202,3 +202,13 @@ a.auth-title-link:active {
   display: flex;
   margin-top: 1rem!important;
 }
+
+table.home-page-statistics td {
+    font-size: 2.0em;
+    font-weight: 300;
+    vertical-align: middle;
+}
+
+table.home-page-statistics th {
+    vertical-align: middle;
+}

--- a/va_explorer/templates/home/index.html
+++ b/va_explorer/templates/home/index.html
@@ -3,31 +3,58 @@
 {% block content %}
 
 <div class="row mt-4">
+  <div class="col">
 
-  <p>VA Explorer is a prototype web application built to demonstrate verbal autopsy data management and analysis capabilities and act as a foundation for exploring new concepts. This prototype represents a work-in-progress, and is expected to mature in response to feedback from users and subject matter experts. VA Explorer currently supports the following functionality at various degrees of maturity:</p>
+    <h2 class="mb-4">VA Explorer Overview for {{ locations }}</h2>
 
-<ul>
-  <li>User account management, including:</li>
-  <ul>
-    <li>Creation/disabling of user accounts by administrators</li>
-    <li>Password management for individual users</li>
-  </ul>
-  <li>User access controls, including:</li>
-  <ul>
-    <li>Role-based access with the following roles: administrators, data managers, data viewers, and field workers</li>
-    <li>Assignment to one or more geographic areas for geographical-level scoping of data</li>
-  </ul>
-  <li>Loading of verbal autopsy questionnaire data</li>
-  <li>Assignment of cause of death using InterVA5 algorithm (Note: relies on external pyCrossVA and InterVA5 services)</li>
-  <li>Exploration of cause of death data via a dynamic, visualization-based dashboard that includes:</li>
-  <ul>
-    <li>A dynamic heatmap showing geographical trends, with zoom capabilities to hone in on regions of interest</li>
-    <li>Cause of death plots for chosen regions</li>
-    <li>Death distributions by age, gender, and place of death for chosen regions</li>
-    <li>Trends over time for chosen regions</li>
-  </ul>
-</ul>
+    <table class="table home-page-statistics">
+      <thead>
+        <tr>
+          <th scope="col">VAs</th>
+          <th scope="col">24 hours</th>
+          <th scope="col">1 week</th>
+          <th scope="col">1 month</th>
+          <th scope="col">Overall</th>
+          <th scope="col">Annual Trend</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Collected</th>
+          <td>{{ vas_collected_24_hours }}</span></td>
+          <td>{{ vas_collected_1_week }}</td>
+          <td>{{ vas_collected_1_month }}</td>
+          <td>{{ vas_collected_overall }}</td>
+          <td>{{ graph_collected|safe }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Coded</th>
+          <td>{{ vas_coded_24_hours }}</td>
+          <td>{{ vas_coded_1_week }}</td>
+          <td>{{ vas_coded_1_month }}</td>
+          <td>{{ vas_coded_overall }}</td>
+          <td>{{ graph_coded|safe }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Not Yet Coded</th>
+          <td>{{ vas_uncoded_24_hours }}</td>
+          <td>{{ vas_uncoded_1_week }}</td>
+          <td>{{ vas_uncoded_1_month }}</td>
+          <td>{{ vas_uncoded_overall }}</td>
+          <td>{{ graph_uncoded|safe }}</td>
+        </tr>
+      </tbody>
+    </table>
 
+    <h2 class="mb-4">VAs With Coding Issues</h2>
+    {% if issue_list %}
+      {% include 'partials/_va_table.html' with va_list=issue_list %}
+      {% if additional_issues > 0 %}<p>There are <a href="/va_data_management/?only_errors=True">{{ additional_issues }} additional issues</a> not listed here</p>{% endif %}
+    {% else %}
+      <p>Excellent, no coding issues found!</p>
+    {% endif %}
+
+</div>
 </div>
 
 {% endblock %}

--- a/va_explorer/templates/partials/_va_table.html
+++ b/va_explorer/templates/partials/_va_table.html
@@ -1,0 +1,28 @@
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Date</th>
+      <th>Name</th>
+      <th>Facility</th>
+      <th>Cause</th>
+      <th>Warnings</th>
+      <th>Errors</th>
+      <th>View</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for va in va_list %}
+    <tr>
+      <td>{{ va.id }}</td>
+      <td>{{ va.date }}</td>
+      <td>{{ va.name }}</td>
+      <td>{{ va.facility }}</td>
+      <td>{{ va.cause }}</td>
+      <td>{{ va.warnings }}</td>
+      <td>{{ va.errors }}</td>
+      <td><a class="btn btn-primary" href="{% url 'data_management:show' id=va.id %}">View</a></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/va_explorer/templates/va_data_management/index.html
+++ b/va_explorer/templates/va_data_management/index.html
@@ -23,34 +23,7 @@
 </form>
 
 <div class="row mt-4">
-  <table class="table table-sm">
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Date</th>
-        <th>Name</th>
-        <th>Facility</th>
-        <th>Cause</th>
-        <th>Warnings</th>
-        <th>Errors</th>
-        <th>View</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for va in object_list %}
-      <tr>
-        <td>{{ va.id }}</td>
-        <td>{{ va.date }}</td>
-        <td>{{ va.name }}</td>
-        <td>{{ va.facility }}</td>
-        <td>{{ va.cause }}</td>
-        <td>{{ va.warnings }}</td>
-        <td>{{ va.errors }}</td>
-        <td><a class="btn btn-primary" href="{% url 'data_management:show' id=va.id %}">View</a></td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  {% include 'partials/_va_table.html' with va_list=object_list %}
   {% if page_obj.has_other_pages %}
   {% include "partials/_pagination.html" %}
   {% endif %}

--- a/va_explorer/va_data_management/management/commands/randomize_va_dates.py
+++ b/va_explorer/va_data_management/management/commands/randomize_va_dates.py
@@ -1,0 +1,32 @@
+from os import environ
+from django.core.management.base import BaseCommand
+from va_explorer.va_data_management.models import VerbalAutopsy
+from random import randint
+from math import sqrt, ceil
+from datetime import date, timedelta
+
+# Demo only: script to ramdomize VA dates for demos of e.g. the metrics page
+
+class Command(BaseCommand):
+
+    help = "Randomize dates for demos, to be run only in development mode"
+
+    def handle(self, *args, **options):
+
+        if not environ.get("DJANGO_SETTINGS_MODULE") == "config.settings.local":
+            message = "This functionality is for demo purposes only in the local environment. Exiting."
+            self.stdout.write(self.style.ERROR(message))
+            exit()
+
+        # Randomize the dates for all VAs in the system so that they take place over
+        # the past ~6 months at (randomness willing) an increasing rate; we want them
+        # to be in the database in increasing date order so we first create a batch of
+        # dates then assign them
+        count = VerbalAutopsy.objects.count()
+        days_list = [183 - ceil(sqrt(randint(1, 183 ** 2))) for _ in range(count)]
+        dates_list = [date.today() - timedelta(days=days) for days in days_list]
+        dates_list.sort()
+        for va, new_date in zip(VerbalAutopsy.objects.all(), dates_list):
+            # Set Id10023 and created and updated all to same date
+            va.Id10023 = va.created = va.updated = new_date
+            va.save()


### PR DESCRIPTION
This pull request:

* Adds some basic metrics and small charts to the home page for the currently logged in user, showing counts of recently collected, coded, and uncoded records for the regions they can access
* Adds a worklist of records that have not been coded that allows the user to immediately address any errors, and a link to view all records with errors
* Refactors record listing into a common shared template
* Adds basic tests

Notes:

* This implementation currently uses the "created" field for categorizing records by date; this should likely use the date the VA is completed, which we don't currently import (note that we do import the date of death, which we display in record listings, but that's not appropriate to use for data collection stats); suggest we implement this in a future PR (this has been captured as https://www.pivotaltracker.com/story/show/177195813)

* There has been some discussion about the best approach for adding graphs to this page (e.g. combining the three current graphs into one graph with different colors); suggest that we defer making further changes until we can get user input on what questions they'd like answered, and allow that to drive graphing and display decisions (this has been captured as https://www.pivotaltracker.com/story/show/177195743)

* The idea of running (or re-running) the coding algorithms via a button on the home page has been suggested; suggest implementing that in a future PR (this has been captured as https://www.pivotaltracker.com/story/show/177195813)

<img width="1206" alt="HomePageMetrics" src="https://user-images.githubusercontent.com/3720400/109881914-0f879c80-7c47-11eb-8845-09f6007188b6.png">
