### PR TITLE
Fix time period run time bug

### DIFF
--- a/va_explorer/utils/plotting.py
+++ b/va_explorer/utils/plotting.py
@@ -21,7 +21,13 @@ PLOTLY = px.colors.qualitative.Plotly
 def load_lookup_dicts():
     lookup = dict()
     # dictionary mapping time labels to days (or all)
-    lookup["time_dict"] = {"1 week": 7, "1 month": 30, "1 year": 365, "all": "all"}
+    lookup["time_dict"] = {"today": 1,
+                        "last week": 7,
+                        "last month": 30,
+                        "last 6 months": 30.4 * 6, # last 182.5 days
+                        "last year": 365,
+                        "all": "all"}
+
     # dictionary mapping demographic variable names to corresponding VA survey columns
     lookup["demo_to_col"] = {
         "age group": "age_group",


### PR DESCRIPTION
This PR addresses this [ticket] (https://www.pivotaltracker.com/story/show/177227398) - "Error when changing dashboard time period".

The time dictionary keys needed to be updated to match the new time periods in the drop down.

Testing:
- run va explorer and navigate to the dashboard
- select different time periods from the drop down
- the map should update with the filtered data
- monitor the logs in the terminal and make sure there is not an internal server error