### PR TITLE
Restrict Dashboard based on geographic access 

### DIFF
--- a/.github/workflows/django-ci-test.yml
+++ b/.github/workflows/django-ci-test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/va_explorer/utils/plotting.py
+++ b/va_explorer/utils/plotting.py
@@ -91,6 +91,17 @@ def load_lookup_dicts():
         "month": "%m/%Y",
         "year": "%Y",
     }
+    
+    # Toolbar configurations for plots
+    # map config
+    lookup['graph_config'] = {"displayModeBar": True,
+          "scrollZoom": True, "displaylogo": False,
+          "modeBarButtonsToRemove":["zoomInGeo", "zoomOutGeo", "select2d", "lasso2d"]}
+    # chart config (for all charts)
+    lookup['chart_config'] = {"displayModeBar": True,
+          "displaylogo":False,
+          "modeBarButtonsToRemove":["pan2d", "zoom2d", "select2d", \
+                        "lasso2d", "zoomIn2d", "zoomOut2d", "autoScale2d", "resetScale2d"]}
 
     return lookup
 

--- a/va_explorer/va_analytics/dash_apps/va_dashboard.py
+++ b/va_explorer/va_analytics/dash_apps/va_dashboard.py
@@ -42,7 +42,7 @@ JSON_DIR = "va_explorer/va_analytics/dash_apps/geojson"
 # Zambia Geojson pulled from: https://adr.unaids.org/dataset/zambia-geographic-data-2019
 JSON_FILE = "zambia_geojson.json"
 # initial granularity
-INITIAL_GRANULARITY = "province"
+INITIAL_GRANULARITY = "district"
 # initial metric to plot on map
 INITIAL_COD_TYPE = "all"
 # ============Lookup dictionaries =================#


### PR DESCRIPTION
This pull request addresses Pivotal story [Link user role and geographical access](https://www.pivotaltracker.com/story/show/176869720).

Testing:
- Confirm Field Worker cannot access Dashboard
- Confirm Data Manager and Data Viewers have access based on geographic restrictions (assign a Data Manager and Data Viewer to only access certain provinces/districts and confirm that only VAs from these areas appear on the Dashboard)

Notes on the use of **expanded_callback** in django_plotly_dash:
- The expanded_callback gives us access to additional arguments passed as kwargs, including the Django user instance.
- As per django_plotly_dash documentation: This function registers the callback function, and sets an internal flag that mandates that ALL callbacks are passed the enhanced arguments
- Thus, we must add **kwargs to all callbacks in the app, even though they are not explicitly designated as "expanded"