### PR TITLE
Fix DJANGO_DEFAULT_FROM_EMAIL

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -203,7 +203,7 @@ EMAIL_PORT = email_config['EMAIL_PORT']
 EMAIL_FILE_PATH = email_config['EMAIL_FILE_PATH']
 EMAIL_TIMEOUT = 5
 
-DEFAULT_FROM_EMAIL = env("DJANGO_DEFAULT_FROM_EMAIL", default="VA Explorer <noreply@va_explorer.org>")
+DEFAULT_FROM_EMAIL = env("DJANGO_DEFAULT_FROM_EMAIL", default="VA Explorer <noreply@vaexplorer.org>")
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 EMAIL_SUBJECT_PREFIX = env("DJANGO_EMAIL_SUBJECT_PREFIX", default="[VA Explorer] ")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-Pimin73y!we}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-dcc02e52ccbb649b9febe9182abfa5e03c49be6c}
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost}
+      DJANGO_DEFAULT_FROM_EMAIL: ${DJANGO_DEFAULT_FROM_EMAIL:-"VA Explorer <noreply@vaexplorer.org>"} 
       PYCROSS_HOST: ${PYCROSS_HOST:-http://pycrossva:80}
       INTERVA_HOST: ${INTERVA_HOST:-http://interva5:5002}
     command: /start


### PR DESCRIPTION
enables setting DJANGO_DEFAULT_FROM_EMAIL from environment variable from docker

va_explorer.org is not valid (domains cannot contain underscores) so the mail server would reject it.