### PR TITLE
Change name from postgres to vapostgres.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ This will build the following docker images:
 ```
 va_explorer/pycrossva
 va_explorer/interva5
-va_explorer/postgres
+va_explorer/vapostgres
 va_explorer/celeryworker
 va_explorer/celerybeat
 va_explorer/flower
@@ -180,7 +180,7 @@ Set the following environment variables:
 export EMAIL_URL=smtp://localhost:25 <or> consolemail://
 export CELERY_BROKER_URL=redis://redis:6379/0
 export REDIS_URL=redis://redis:6379/0
-export POSTGRES_HOST=postgres
+export POSTGRES_HOST=vapostgres
 export POSTGRES_PORT=5432
 export POSTGRES_DB=va_explorer
 export POSTGRES_USER=postgres

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -22,7 +22,7 @@ services:
       DJANGO_ALLOWED_HOSTS: 0.0.0.0,127.0.0.1,localhost,va_explorer.org
       EMAIL_URL: consolemail://
       
-  postgres:
+  vapostgres:
     volumes:
       - local_postgres_data:/var/lib/postgresql/data
       - local_postgres_data_backups:/backups

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       EMAIL_URL: ${EMAIL_URL:-smtp://localhost:25}
       CELERY_BROKER_URL: ${CELERY_BROKER_URL:-redis://redis:6379/0}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
-      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+      POSTGRES_HOST: ${POSTGRES_HOST:-vapostgres}
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}
       POSTGRES_DB: ${POSTGRES_DB:-va_explorer}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
@@ -66,7 +66,7 @@ services:
     image: va_explorer/flower
     command: /start-celeryflower
 
-  postgres:
+  vapostgres:
     image: va_explorer/postgres
     build:
       context: .


### PR DESCRIPTION
When we connect the ODK and VA docker networks, there is a conflicting service named `postgres`.

Renaming the service on our side is the easiest way to remove the conflict. This changes the name to `vapostgres`.