### PR TITLE
Fix for users with blank usernames

### DIFF
--- a/va_explorer/users/forms.py
+++ b/va_explorer/users/forms.py
@@ -201,21 +201,12 @@ class ExtendedUserCreationForm(UserCommonFields, UserCreationForm):
             location_restrictions = get_location_restrictions(self.cleaned_data)
             group = self.cleaned_data["group"]
 
-            va_username = None
-
-            if self.cleaned_data["va_username"]:
-                va_username = VaUsername(va_username=self.cleaned_data["va_username"], user=user)
-
             if commit:
-                user.save()
-
                 # You cannot associate the user with a m2m field until it’s been saved
                 # https://docs.djangoproject.com/en/3.1/topics/db/examples/many_to_many/
                 user.location_restrictions.add(*location_restrictions)
                 user.groups.add(*[group])
-
-                if va_username:
-                    va_username.save()
+                user.set_va_username(self.cleaned_data["va_username"])
 
                 # If selected group cannot view PII, modify the user's permissions according to the checkbox.
                 if not self.cleaned_data['group'].permissions.filter(codename='view_pii').first():

--- a/va_explorer/users/forms.py
+++ b/va_explorer/users/forms.py
@@ -206,7 +206,7 @@ class ExtendedUserCreationForm(UserCommonFields, UserCreationForm):
                 # https://docs.djangoproject.com/en/3.1/topics/db/examples/many_to_many/
                 user.location_restrictions.add(*location_restrictions)
                 user.groups.add(*[group])
-                user.set_va_username(self.cleaned_data["va_username"])
+                user.set_va_username(self.cleaned_data.get("va_username"))
 
                 # If selected group cannot view PII, modify the user's permissions according to the checkbox.
                 if not self.cleaned_data['group'].permissions.filter(codename='view_pii').first():
@@ -282,7 +282,7 @@ class UserUpdateForm(UserCommonFields, forms.ModelForm):
             """
             user.location_restrictions.set(location_restrictions)
             user.groups.set([group])
-            user.set_va_username(self.cleaned_data["va_username"])
+            user.set_va_username(self.cleaned_data.get("va_username"))
 
             # If selected group cannot view PII, modify the user's permissions according to the checkbox.
             if not self.cleaned_data['group'].permissions.filter(codename='view_pii').first():

--- a/va_explorer/users/forms.py
+++ b/va_explorer/users/forms.py
@@ -202,6 +202,9 @@ class ExtendedUserCreationForm(UserCommonFields, UserCreationForm):
             group = self.cleaned_data["group"]
 
             if commit:
+                # Need to save again after setting password.
+                user.save()
+
                 # You cannot associate the user with a m2m field until it’s been saved
                 # https://docs.djangoproject.com/en/3.1/topics/db/examples/many_to_many/
                 user.location_restrictions.add(*location_restrictions)

--- a/va_explorer/users/models.py
+++ b/va_explorer/users/models.py
@@ -93,27 +93,14 @@ class User(AbstractUser):
             self.user_permissions.remove(permission)
 
     # TODO: Update this if we are supporting more than one username; for now, allow only one
-    def set_va_username(self, *va_usernames):
-        # Find if the user has an existing va_username
-        try:
-            user_va_username = self.vausername_set.first()
-        except:
-            user_va_username = None
+    def set_va_username(self, new_va_username):
+        # If None or blank string, delete existing username.
+        if not new_va_username:
+            self.vausername_set.all().delete()
+            return
 
-        # If user has no existing va_username, create one
-        if not user_va_username and va_usernames:
-            self.vausername_set.create(va_username=va_usernames[0])
-
-        # If user has a new, non-blank va_username, replace the existing one
-        elif (user_va_username and va_usernames[0]) and \
-            (va_usernames[0] != user_va_username):
-            user_va_username.va_username = va_usernames[0]
-            user_va_username.save()
-
-        # If the user has an existing va_username, but there is none on the update form,
-        # delete the existing one
-        elif user_va_username and not va_usernames[0]:
-            user_va_username.delete()
+        # Update or create the VaUsername for this user. There should only be one.
+        self.vausername_set.update_or_create(defaults={'va_username': new_va_username})
 
     # TODO: Update this if we are supporting more than one username; for now, allow only one
     def get_va_username(self):

--- a/va_explorer/users/tests/test_forms.py
+++ b/va_explorer/users/tests/test_forms.py
@@ -358,6 +358,46 @@ class TestUserUpdateForm:
         assert len(form.errors) == 1
         assert "group" in form.errors
 
+    def test_blank_usernames(self):
+        # At the time of writing, this is testing a bug.
+        # The UserUpdateForm will create a VaUsername with a blank username.
+        # This means that the below would fail since it's a unique field and 2 users
+        # cannot have the same "blank" username.
+        # So I added this test and then fixed the code to verify.
+   
+        field_worker_group = FieldWorkerGroupFactory.create()
+        location = LocationFactory.create()
+
+        user1 = NewUserFactory.build()
+        user2 = NewUserFactory.build()
+   
+        form = UserUpdateForm(
+            {
+                "name": user1.name,
+                "email": user1.email,
+                "group": field_worker_group,
+                "geographic_access": "location-specific",
+                "location_restrictions": [location],
+                "va_username": "",
+            }
+        )
+
+        assert form.save()
+
+        form = UserUpdateForm(
+            {
+                "name": user2.name,
+                "email": user2.email,
+                "group": field_worker_group,
+                "geographic_access": "location-specific",
+                "location_restrictions": [location],
+                "va_username": "",
+            }
+        )
+
+        assert form.save()
+
+
 
 class TestUserSetPasswordForm:
     def test_valid_form(self, rf: RequestFactory):


### PR DESCRIPTION
When editing a user, currently the logic will create a VaUsername with a blank username.

This causes a problem when trying to edit another user because the va_username is marked as a unique field so it will try to create another VaUsername with a blank username, resulting in an Integrity error.

```
django.db.utils.IntegrityError: duplicate key value violates unique constraint "va_data_management_vausername_va_username_key"
DETAIL:  Key (va_username)=() already exists.
```

Added a regression test to illustrate the issue and then fixed the code so the test passes.

Was also able to simplify the code in the form and model while doing so.