### PR TITLE
ensured reset password email is printed to console 

### DIFF
--- a/va_explorer/templates/account/email/base_message.txt
+++ b/va_explorer/templates/account/email/base_message.txt
@@ -1,0 +1,7 @@
+{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name %}Hello from {{ site_name }}!{% endblocktrans %}
+
+{% block content %}{% endblock %}
+
+{% blocktrans with site_name=current_site.name site_domain=va_explorer.com %}Thank you for using {{ site_name }}!
+{{ site_domain }}{% endblocktrans %}
+{% endautoescape %}

--- a/va_explorer/users/adapters.py
+++ b/va_explorer/users/adapters.py
@@ -9,7 +9,12 @@ EMAIL_URL = os.environ.get('EMAIL_URL', 'consolemail://')
 class AccountAdapter(DefaultAccountAdapter):
     def is_open_for_signup(self, request: HttpRequest):
         return getattr(settings, "ACCOUNT_ALLOW_REGISTRATION", False)
-
+    
+    # OVERRIDING ALLAUTH METHOD TO BOTH PRINT MSG TO CONSOLE AND SEND MESSAGE
+    def send_mail(self, template_prefix, email, context):
+        msg = self.render_mail(template_prefix, email, context)
+        self.send_and_print_message(msg)
+    
     # https://github.com/pennersr/django-allauth/blob/c19a212c6ee786af1bb8bc1b07eb2aa8e2bf531b/allauth/account/adapter.py#L97
     def send_new_user_mail(self, request, user, temporary_password):
         url = request.build_absolute_uri(reverse("account_login"))
@@ -21,14 +26,18 @@ class AccountAdapter(DefaultAccountAdapter):
         }
         email_template = "account/email/new_user"
         message = self.render_mail(email_template, user.email, ctx)
-                
+        self.send_and_print_message(message)
+
+    # trys to send email via email server but always prints message to console, regardless of if email went through
+    def send_and_print_message(self, message):
         # ensure credentials get written to stdout, regardless of email backend
         if not ("console" in settings.EMAIL_BACKEND and EMAIL_URL.startswith("consolemail")):
             print(message.message())
-        
         try:
             message.send()
         except ConnectionRefusedError:
             print("WARNING: could not send email because connection was refused. Ensure that EMAIL_URL environment variable and all Django email settings are correct.")
             print(f"\t(see base or production files in config.settings). Current EMAIL_URL: {EMAIL_URL}")
             print(message.message())
+
+    

--- a/va_explorer/users/migrations/0010_change_default_site_name.py
+++ b/va_explorer/users/migrations/0010_change_default_site_name.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+
+def setup_default_site(apps, schema_editor):
+    """
+    Set up or rename the default example.com site created by Django.
+    """
+    Site = apps.get_model("sites", "Site")
+
+    name = "VA Explorer"
+    domain = "vaexplorer.org"
+
+    try:
+        site = Site.objects.get(domain="example.com")
+        site.name = name
+        site.domain = domain
+        site.save()
+
+    except Site.DoesNotExist:
+        # No site with domain example.com exists.
+        # Create a default site, but only if no sites exist.
+        if Site.objects.count() == 0:
+            Site.objects.create(name=name, domain=domain)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        # ('contenttypes', 'name': '0001_initial)'
+        # ("sites", "0002_alter_domain_unique"),
+        ("users", "0009_auto_20210608_1950")
+    ]
+
+    operations = [
+        migrations.RunPython(setup_default_site, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
also replaced` example.com` in subject header/footer with VA Explorer. Addresses Issue 2 in the pilot tracker. 

Note: need to run `makemigrations` and `migrate` for the example.com change to work