### PR TITLE
Add loading indicator for initial dashboard load

### DIFF
--- a/va_explorer/va_analytics/dash_apps/va_dashboard.py
+++ b/va_explorer/va_analytics/dash_apps/va_dashboard.py
@@ -29,11 +29,7 @@ from va_explorer.va_analytics.utils import plotting, loading, rendering
 # ================APP DEFINITION===============#
 # NOTE: to include external stylesheets, set external_stylesheets parameter in constructor
 # app = dash.Dash(__name__)  # Dash constructor
-app = DjangoDash(
-        name="va_dashboard",
-        serve_locally=True,
-        add_bootstrap_links=True,
-  )
+app = DjangoDash(name="va_dashboard", serve_locally=True, add_bootstrap_links=True,)
 
 
 # NOTE: moved Toolbar configurations to plotting.py
@@ -64,7 +60,6 @@ app.layout = html.Div(
     id="app-body-container",
     children=[
         html.Div(
-
             [
                 html.Div(id="va_update_stats"),
                 # global filters (affect entire dashboard)
@@ -149,313 +144,358 @@ app.layout = html.Div(
                     ],
                     style={"padding-bottom": "10px"},
                 ),
-                dbc.Row(
-                    [
-                        dbc.Col(
+                dcc.Loading(
+                    id="map-loader",
+                    type="circle",
+                    children=[
+                        dbc.Row(
                             [
-                                dbc.Row(
+                                dbc.Col(
                                     [
-                                        html.Div(
-                                            id="callout-container",
-                                            style={
-                                                "display": "contents",
-                                                "text-align": "center",
-                                            },
-                                        )
-                                    ],
-                                    style={"margin-left": "0px"},
-                                ),
-                                dbc.Row(
-                                    [
-                                        html.Span(
-                                            className="fas fa-search",
-                                            style={"margin-top": "10px"},
-                                        ),
-                                        html.Div(
-                                            className="dashborad-comp-container",
-                                            id="search-container",
-                                            children=[
-                                                dcc.Dropdown(
-                                                    id="map_search",
-                                                    options=[],
-                                                    multi=False,
-                                                    placeholder="Search Locations (or click on map)",
-                                                    clearable=True,
+                                        dbc.Row(
+                                            [
+                                                html.Div(
+                                                    id="callout-container",
+                                                    style={
+                                                        "display": "contents",
+                                                        "text-align": "center",
+                                                    },
                                                 )
                                             ],
-                                            style={
-                                                "margin-left": "10px",
-                                                "width": "80%",
-                                            },
+                                            style={"margin-left": "0px"},
                                         ),
-                                         html.Div(
-                                            className="dashboard-comp-container",
-                                            children=[
-                                                dcc.Dropdown(
-                                                    id="view_level",
-                                                    value="",
-                                                    placeholder="View",
+                                        dbc.Row(
+                                            [
+                                                html.Span(
+                                                    className="fas fa-search",
+                                                    style={"margin-top": "10px"},
+                                                ),
+                                                html.Div(
+                                                    className="dashborad-comp-container",
+                                                    id="search-container",
+                                                    children=[
+                                                        dcc.Dropdown(
+                                                            id="map_search",
+                                                            options=[],
+                                                            multi=False,
+                                                            placeholder="Search Locations (or click on map)",
+                                                            clearable=True,
+                                                        )
+                                                    ],
                                                     style={
-                                                        "margin-bottom": "5px",
-                                                        "width": "100px",
+                                                        "margin-left": "10px",
+                                                        "width": "80%",
                                                     },
-                                                    searchable=False,
-                                                    clearable=False,
-                                                    disabled=False,
+                                                ),
+                                                html.Div(
+                                                    className="dashboard-comp-container",
+                                                    children=[
+                                                        dcc.Dropdown(
+                                                            id="view_level",
+                                                            value="",
+                                                            placeholder="View",
+                                                            style={
+                                                                "margin-bottom": "5px",
+                                                                "width": "100px",
+                                                            },
+                                                            searchable=False,
+                                                            clearable=False,
+                                                            disabled=False,
+                                                        ),
+                                                    ],
                                                 ),
                                             ],
+                                            style={
+                                                "padding-left": "20px",
+                                                "padding-right": "15px",
+                                                "margin-top": "15px",
+                                                "padding-bottom": "10px",
+                                            },
+                                        ),
+                                        dbc.Row([], style={"align-items": "center"},),
+                                        # map container
+                                        dcc.Loading(
+                                            id="map-loader",
+                                            type="circle",
+                                            children=[
+                                                html.Div(
+                                                    id="choropleth-container",
+                                                    children=dcc.Graph(id="choropleth"),
+                                                )
+                                            ],
+                                        ),
+                                        html.Div(id="bounds"),
+                                        # data stores
+                                        dcc.Store(id="va_data"),
+                                        dcc.Store(id="invalid_va_data"),
+                                        dcc.Store(id="locations"),
+                                        dcc.Store(id="location_types"),
+                                        dcc.Store(id="filter_dict"),
+                                        # used to trigger data ingest when page first loads
+                                        html.Div(
+                                            id="hidden_trigger",
+                                            style={"display": "none"},
                                         ),
                                     ],
+                                    width=7,
                                     style={
-                                        "padding-left": "20px",
-                                        "padding-right": "15px",
-                                        "margin-top": "15px",
-                                        "padding-bottom": "10px",
+                                        "min-width": "480px",
+                                        "margin-bottom": "15px",
                                     },
                                 ),
-                                dbc.Row([], style={"align-items": "center"},),
-                                # map container
-                                dcc.Loading(
-                                    id="map-loader",
-                                    type="circle",
-                                    children=[
-                                        html.Div(
-                                            id="choropleth-container",
-                                            children=dcc.Graph(id="choropleth"),
-                                        )
-                                    ],
-                                ),
-                                html.Div(id="bounds"),
-                                
-                                # data stores
-                                dcc.Store(id="va_data"),
-                                dcc.Store(id="invalid_va_data"),
-                                dcc.Store(id="locations"),
-                                dcc.Store(id="location_types"),
-                                dcc.Store(id="filter_dict"),
-
-                                # used to trigger data ingest when page first loads
-                                html.Div(id="hidden_trigger", style={"display": "none"})
-                            ],
-                            width=7,
-                            style={"min-width": "480px", "margin-bottom": "15px"},
-                        ),
-                        dbc.Col(
-                            [
-                                dcc.Tabs(
-                                    id="plot_tabs",
-                                    children=[  # graph tabs
-                                        dcc.Tab(
-                                            id="cod_tab",
-                                            label="COD Analysis",
-                                            children=[  # tab 1: COD Analysis
-                                                html.Div(
-                                                    id="cod_buttons",
-                                                    children=[
-                                                        dbc.Row(
-                                                            [
-                                                                dbc.Col(
+                                dbc.Col(
+                                    [
+                                        dcc.Tabs(
+                                            id="plot_tabs",
+                                            children=[  # graph tabs
+                                                dcc.Tab(
+                                                    id="cod_tab",
+                                                    label="COD Analysis",
+                                                    children=[  # tab 1: COD Analysis
+                                                        html.Div(
+                                                            id="cod_buttons",
+                                                            children=[
+                                                                dbc.Row(
                                                                     [
-                                                                        dcc.Dropdown(
-                                                                            id="cod_n",
-                                                                            options=[
-                                                                                {
-                                                                                    "label": f"Top {o}",
-                                                                                    "value": o,
-                                                                                }
-                                                                                for o in [
-                                                                                    5,
-                                                                                    10,
-                                                                                    15,
-                                                                                    20,
-                                                                                ]
+                                                                        dbc.Col(
+                                                                            [
+                                                                                dcc.Dropdown(
+                                                                                    id="cod_n",
+                                                                                    options=[
+                                                                                        {
+                                                                                            "label": f"Top {o}",
+                                                                                            "value": o,
+                                                                                        }
+                                                                                        for o in [
+                                                                                            5,
+                                                                                            10,
+                                                                                            15,
+                                                                                            20,
+                                                                                        ]
+                                                                                    ],
+                                                                                    value=10,
+                                                                                    style={
+                                                                                        "margin-top": "5px",
+                                                                                        "margin-bottom": "5px",
+                                                                                    },
+                                                                                    searchable=False,
+                                                                                    clearable=False,
+                                                                                )
                                                                             ],
-                                                                            value=10,
-                                                                            style={
-                                                                                "margin-top": "5px",
-                                                                                "margin-bottom": "5px",
-                                                                            },
-                                                                            searchable=False,
-                                                                            clearable=False,
-                                                                        )
-                                                                    ],
-                                                                    width=3,
-                                                                ),
-    
-                                                                # COD groups dropdown
-                                                                dbc.Col([
-                                                                            dcc.Dropdown(
-                                                                             id='cod_group',
-                                                                             options=[
-                                                                                {
-                                                                                    "label": LOOKUP['display_names'].get(o,o.capitalize()), 
-                                                                                    "value": o,                                                                                         
-                                                                                }
-                                                                                for o in ['All CODs'] + COD_GROUPS.columns[2:].tolist()
-                                                                            ], 
-                                                                            value='All CODs', 
-                                                                            style={
-                                                                                "margin-top": "5px",
-                                                                                "margin-bottom": "5px",
-                                                                            },
-                                                                            searchable=True,
-                                                                            clearable=False,
-                                                                            multi=True,
-                                                                                    
-                                                                            )
-                                                                            ], width=5),
-                                                                # COD factor (demographic) dropdown
-                                                                dbc.Col([
-                                                                        dcc.Dropdown(
-                                                                            id="cod_factor",
-                                                                            options=[
-                                                                                {
-                                                                                    "label": "By {}".format(o) if o != "Overall" else o,
-                                                                                    "value": o,
-                                                                                }
-                                                                                for o in [
-                                                                                    "Overall",
-                                                                                    "Age Group",
-                                                                                    "Sex",
-                                                                                    "Place of Death",
-                                                                                ]
+                                                                            width=3,
+                                                                        ),
+                                                                        # COD groups dropdown
+                                                                        dbc.Col(
+                                                                            [
+                                                                                dcc.Dropdown(
+                                                                                    id="cod_group",
+                                                                                    options=[
+                                                                                        {
+                                                                                            "label": LOOKUP[
+                                                                                                "display_names"
+                                                                                            ].get(
+                                                                                                o,
+                                                                                                o.capitalize(),
+                                                                                            ),
+                                                                                            "value": o,
+                                                                                        }
+                                                                                        for o in [
+                                                                                            "All CODs"
+                                                                                        ]
+                                                                                        + COD_GROUPS.columns[
+                                                                                            2:
+                                                                                        ].tolist()
+                                                                                    ],
+                                                                                    value="All CODs",
+                                                                                    style={
+                                                                                        "margin-top": "5px",
+                                                                                        "margin-bottom": "5px",
+                                                                                    },
+                                                                                    searchable=True,
+                                                                                    clearable=False,
+                                                                                    multi=True,
+                                                                                )
                                                                             ],
-                                                                            value="Overall",
-                                                                            style={
-                                                                                "margin-top": "5px",
-                                                                                "margin-bottom": "5px",
-                                                                                "width": "150px",
-                                                                            },
-                                                                            searchable=False,
-                                                                            clearable=False,
+                                                                            width=5,
+                                                                        ),
+                                                                        # COD factor (demographic) dropdown
+                                                                        dbc.Col(
+                                                                            [
+                                                                                dcc.Dropdown(
+                                                                                    id="cod_factor",
+                                                                                    options=[
+                                                                                        {
+                                                                                            "label": "By {}".format(
+                                                                                                o
+                                                                                            )
+                                                                                            if o
+                                                                                            != "Overall"
+                                                                                            else o,
+                                                                                            "value": o,
+                                                                                        }
+                                                                                        for o in [
+                                                                                            "Overall",
+                                                                                            "Age Group",
+                                                                                            "Sex",
+                                                                                            "Place of Death",
+                                                                                        ]
+                                                                                    ],
+                                                                                    value="Overall",
+                                                                                    style={
+                                                                                        "margin-top": "5px",
+                                                                                        "margin-bottom": "5px",
+                                                                                        "width": "150px",
+                                                                                    },
+                                                                                    searchable=False,
+                                                                                    clearable=False,
+                                                                                ),
+                                                                            ],
+                                                                            width=4,
                                                                         ),
                                                                     ],
-                                                                    width=4,
+                                                                    style={
+                                                                        "margin-top": "5px"
+                                                                    },
+                                                                ),
+                                                                dcc.Loading(
+                                                                    html.Div(
+                                                                        id="cod-container"
+                                                                    ),
+                                                                    type="circle",
                                                                 ),
                                                             ],
-                                                            style={"margin-top": "5px"}
-                                                        ),
+                                                        )
+                                                    ],
+                                                ),
+                                                dcc.Tab(
+                                                    label="Demographics",
+                                                    id="demographic_tab",
+                                                    children=[
                                                         dcc.Loading(
                                                             html.Div(
-                                                                id="cod-container"
+                                                                id="demos-container"
                                                             ),
                                                             type="circle",
-                                                        ),
+                                                        )
                                                     ],
-                                                )
-                                            ],
-                                        ),
-                                        dcc.Tab(
-                                            label="Demographics",
-                                            id="demographic_tab",
-                                            children=[
-                                                dcc.Loading(
-                                                    html.Div(id="demos-container"),
-                                                    type="circle",
-                                                )
-                                            ],
-                                        ),
-                                        dcc.Tab(
-                                            label="VA Trends",
-                                            id="trend_tab",
-                                            children=[
-                                                html.Div(
-                                                    id="ts_buttons",
+                                                ),
+                                                dcc.Tab(
+                                                    label="VA Trends",
+                                                    id="trend_tab",
                                                     children=[
-                                                        dbc.Row(
-                                                            [
-                                                                html.Div(
-                                                                        className="dashboard-comp-container",
-                                                                        children=[
-                                                                            dcc.Dropdown(
-                                                                                 id='ts_search',
-                                                                                options = [{"label": "All Causes", "value": "All causes.all"}],
-                                                                                placeholder = "Search COD Keywords",
-                                                                                style={
-                                                                                    "margin-top": "5px",
-                                                                                    "margin-bottom": "5px",
-                                                                                    "width": "250px"
-                                                                                },
-                                                                                searchable=True,
-                                                                                clearable=True,
-                                                                                multi=True,
-                                                                                value="All causes.all"
-                                                                                                
-                                                                            )]
-                                                                ),
-                                                                html.Div(
-                                                                        className="dashboard-comp-container",
-                                                                        children=[
-                                                                        dcc.Dropdown(
-                                                                            id="ts_factor",
-                                                                            options=[
-                                                                                {
-                                                                                    "label": "By {}".format(o) if o != "Overall" else o,
-                                                                                    "value": o,
-                                                                                }
-                                                                                for o in [
-                                                                                    "Overall",
-                                                                                    "Age Group",
-                                                                                    "Sex",
-                                                                                    "Place of Death",
-                                                                                ]
+                                                        html.Div(
+                                                            id="ts_buttons",
+                                                            children=[
+                                                                dbc.Row(
+                                                                    [
+                                                                        html.Div(
+                                                                            className="dashboard-comp-container",
+                                                                            children=[
+                                                                                dcc.Dropdown(
+                                                                                    id="ts_search",
+                                                                                    options=[
+                                                                                        {
+                                                                                            "label": "All Causes",
+                                                                                            "value": "All causes.all",
+                                                                                        }
+                                                                                    ],
+                                                                                    placeholder="Search COD Keywords",
+                                                                                    style={
+                                                                                        "margin-top": "5px",
+                                                                                        "margin-bottom": "5px",
+                                                                                        "width": "250px",
+                                                                                    },
+                                                                                    searchable=True,
+                                                                                    clearable=True,
+                                                                                    multi=True,
+                                                                                    value="All causes.all",
+                                                                                )
                                                                             ],
-                                                                            value="Overall",
-                                                                            style={
-                                                                                "margin-top": "5px",
-                                                                                "margin-bottom": "5px",
-                                                                                "width": "150px",
-                                                                            },
-                                                                            searchable=False,
-                                                                            clearable=False,
-                                                                        )
-                                                                    ]
-                                                                ),
-
-                                                            html.Div(
-                                                                    className="dashboard-comp-container",
-                                                                    children=[
-                                                                        dcc.Dropdown(
-                                                                            id="group_period",
-                                                                            options=[
-                                                                                {
-                                                                                    "label": f"By {o}",
-                                                                                    "value": o,
-                                                                                }
-                                                                                for o in [
-                                                                                    "Day",
-                                                                                    "Week",
-                                                                                    "Month",
-                                                                                    "Year",
-                                                                                ]
-                                                                            ],
-                                                                            value="Month",
-                                                                            style={
-                                                                                "margin-top": "5px",
-                                                                                "margin-bottom": "5px",
-                                                                                "width": "120px",
-                                                                            },
-                                                                            searchable=False,
-                                                                            clearable=False,
                                                                         ),
-                                                                       ]
-                                                                )
-
+                                                                        html.Div(
+                                                                            className="dashboard-comp-container",
+                                                                            children=[
+                                                                                dcc.Dropdown(
+                                                                                    id="ts_factor",
+                                                                                    options=[
+                                                                                        {
+                                                                                            "label": "By {}".format(
+                                                                                                o
+                                                                                            )
+                                                                                            if o
+                                                                                            != "Overall"
+                                                                                            else o,
+                                                                                            "value": o,
+                                                                                        }
+                                                                                        for o in [
+                                                                                            "Overall",
+                                                                                            "Age Group",
+                                                                                            "Sex",
+                                                                                            "Place of Death",
+                                                                                        ]
+                                                                                    ],
+                                                                                    value="Overall",
+                                                                                    style={
+                                                                                        "margin-top": "5px",
+                                                                                        "margin-bottom": "5px",
+                                                                                        "width": "150px",
+                                                                                    },
+                                                                                    searchable=False,
+                                                                                    clearable=False,
+                                                                                )
+                                                                            ],
+                                                                        ),
+                                                                        html.Div(
+                                                                            className="dashboard-comp-container",
+                                                                            children=[
+                                                                                dcc.Dropdown(
+                                                                                    id="group_period",
+                                                                                    options=[
+                                                                                        {
+                                                                                            "label": f"By {o}",
+                                                                                            "value": o,
+                                                                                        }
+                                                                                        for o in [
+                                                                                            "Day",
+                                                                                            "Week",
+                                                                                            "Month",
+                                                                                            "Year",
+                                                                                        ]
+                                                                                    ],
+                                                                                    value="Month",
+                                                                                    style={
+                                                                                        "margin-top": "5px",
+                                                                                        "margin-bottom": "5px",
+                                                                                        "width": "120px",
+                                                                                    },
+                                                                                    searchable=False,
+                                                                                    clearable=False,
+                                                                                ),
+                                                                            ],
+                                                                        ),
+                                                                    ],
+                                                                ),
+                                                                dcc.Loading(
+                                                                    html.Div(
+                                                                        id="ts-container"
+                                                                    ),
+                                                                    type="circle",
+                                                                ),
                                                             ],
-                                                        ),
-                                                        dcc.Loading(
-                                                            html.Div(id="ts-container"),
-                                                            type="circle",
-                                                        ),
+                                                        )
                                                     ],
-                                                )
+                                                ),
                                             ],
-                                        ),
-                                    ]
-                                )
+                                        )
+                                    ],
+                                    width=5,
+                                    style={
+                                        "min-width": "480px",
+                                        "margin-bottom": "15px",
+                                        "margin-top": "40px",
+                                    },
+                                ),
                             ],
-                            width=5,
-                            style={"min-width": "480px", "margin-bottom": "15px", "margin-top": "40px"},
                         ),
                     ],
                 ),
@@ -474,14 +514,13 @@ app.layout = html.Div(
     ],
     [Input(component_id="reset", component_property="n_clicks")],
 )
-
 def reset_dashboard(n_clicks=0, **kwargs):
     write_va_log(LOGGER, f"[dashboard] Clicked Reset Button", kwargs["request"])
     return "", INITIAL_COD_TYPE, INITIAL_TIMEFRAME
 
 
 # ============ VA data (loaded from database and shared across components) ========
-'''
+"""
 Note on the use of expanded_callback in django_plotly_dash
 
 The expanded_callback gives us access to additional arguments passed as kwargs, including
@@ -493,27 +532,31 @@ ALL callbacks are passed the enhanced arguments
 
 Thus, we must add **kwargs to all callbacks in the app, even though they are not explicitly
 designated as "expanded"
-'''
+"""
+
+
 @app.expanded_callback(
     [
         Output(component_id="va_data", component_property="data"),
         Output(component_id="invalid_va_data", component_property="data"),
         Output(component_id="locations", component_property="data"),
         Output(component_id="location_types", component_property="data"),
-        Output(component_id="download_data_div", component_property="children"), #download button
-        Output(component_id="va_update_stats", component_property="children") # stats on last update
-
+        Output(
+            component_id="download_data_div", component_property="children"
+        ),  # download button
+        Output(
+            component_id="va_update_stats", component_property="children"
+        ),  # stats on last update
     ],
     [Input(component_id="hidden_trigger", component_property="children")],
 )
-
 def init_va_data(hidden_trigger=None, **kwargs):
-    date_cutoff=None
+    date_cutoff = None
     timeframe = LOOKUP["time_dict"].get(INITIAL_TIMEFRAME, "all")
     if timeframe != "all":
         date_cutoff = dt.datetime.today() - dt.timedelta(timeframe)
 
-    res = loading.load_va_data(kwargs['user'], date_cutoff=date_cutoff)
+    res = loading.load_va_data(kwargs["user"], date_cutoff=date_cutoff)
     valid_va_data = res["data"]["valid"].to_dict()
     invalid_va_data = res["data"]["invalid"].to_dict()
     locations = res.get("locations", [])
@@ -526,25 +569,37 @@ def init_va_data(hidden_trigger=None, **kwargs):
     download_div = html.Div(id="download_data_button")
     if kwargs["user"].can_download_data:
         download_div.children = [
-            dbc.Button("Download Data", href="/va_analytics/download", color="primary", external_link=True),
+            dbc.Button(
+                "Download Data",
+                href="/va_analytics/download",
+                color="primary",
+                external_link=True,
+            ),
         ]
 
-    return valid_va_data, invalid_va_data, locations, location_types, download_div, update_div
+    return (
+        valid_va_data,
+        invalid_va_data,
+        locations,
+        location_types,
+        download_div,
+        update_div,
+    )
+
 
 # ============ Location search options (loaded after load_va_data())==================
 @app.callback(
     Output(component_id="log_data", component_property="children"),
-    [Input(component_id="plot_tabs", component_property="value")]
-
+    [Input(component_id="plot_tabs", component_property="value")],
 )
 def log_tab_value(tab_value, **kwargs):
     tab_names = {"tab-1": "COD", "tab-2": "Demographics", "tab-3": "VA Trends"}
     tab_name = tab_names.get(tab_value, None)
     if tab_name:
-        write_va_log(LOGGER, f"[dashboard] Clicked on {tab_name} Tab ", kwargs["request"])
+        write_va_log(
+            LOGGER, f"[dashboard] Clicked on {tab_name} Tab ", kwargs["request"]
+        )
     return tab_name
-    
-
 
 
 # ============ Location search options (loaded after load_va_data())==================
@@ -569,11 +624,11 @@ def update_map_options(search_value, locations, **kwargs):
 
 # ============ Filter logic (update filter table used by other componenets)========#
 @app.callback(
-#    [
-        Output(component_id="filter_dict", component_property="data"),
-#        Output(component_id="timeframe", component_property="disabled"),
-#        Output(component_id="bounds", component_property="children")
-#    ],
+    #    [
+    Output(component_id="filter_dict", component_property="data"),
+    #        Output(component_id="timeframe", component_property="disabled"),
+    #        Output(component_id="bounds", component_property="children")
+    #    ],
     [
         Input(component_id="va_data", component_property="data"),
         Input(component_id="invalid_va_data", component_property="data"),
@@ -594,7 +649,7 @@ def filter_data(
     search_terms=[],
     locations=None,
     location_types=None,
-    **kwargs
+    **kwargs,
 ):
     if va_data is not None:
         valid_va_df = pd.DataFrame(va_data)
@@ -602,10 +657,12 @@ def filter_data(
         invalid_va_df = pd.DataFrame(invalid_va_data)
         invalid_va_df["date"] = pd.to_datetime(invalid_va_df["date"])
         search_terms = [] if search_terms is None else search_terms
-        
+
         # get user location restrictions. If none, will return an empty queryset
-        location_restrictions = kwargs["user"].location_restrictions.values("name", "id")
-            
+        location_restrictions = kwargs["user"].location_restrictions.values(
+            "name", "id"
+        )
+
         # if no selected json, convert to empty dictionary for easier processing
         selected_json = {} if not selected_json else selected_json
 
@@ -617,7 +674,7 @@ def filter_data(
             location_types=location_types,
             search_terms=search_terms,
             locations=locations,
-            restrictions=location_restrictions
+            restrictions=location_restrictions,
         )
         # filter invalid vas (VAs without COD)
         invalid_filter = _get_filter_dict(
@@ -627,15 +684,19 @@ def filter_data(
             location_types=location_types,
             search_terms=search_terms,
             locations=locations,
-            restrictions=location_restrictions
-        )      
-        
+            restrictions=location_restrictions,
+        )
+
         combined_filter_dict = {
             "plot_regions": valid_filter["plot_regions"],  # same across both dicts
             "granularity": valid_filter["granularity"],  # same across both dictionaries
-            "search_filter": valid_filter["search_filter"], # same across both dictionaries
+            "search_filter": valid_filter[
+                "search_filter"
+            ],  # same across both dictionaries
             "geo_filter": valid_filter["geo_filter"],  # same across both dictionaries
-            "chosen_region": valid_filter["chosen_region"],  # same across both dictionaries
+            "chosen_region": valid_filter[
+                "chosen_region"
+            ],  # same across both dictionaries
             "ids": {"valid": valid_filter["ids"], "invalid": invalid_filter["ids"]},
             "cod_type": cod_type,
             "plot_ids": {
@@ -643,10 +704,11 @@ def filter_data(
                 "invalid": invalid_filter["plot_ids"],
             },
         }
-            
+
         log_callback_trigger(LOGGER, dash.callback_context, kwargs["request"])
 
-        return combined_filter_dict #, disable_timeframe
+        return combined_filter_dict  # , disable_timeframe
+
 
 def log_callback_trigger(logger, context, request):
     if context:
@@ -668,10 +730,9 @@ def log_callback_trigger(logger, context, request):
                     action = "Changed COD Type to"
                 elif component_id == "timeframe":
                     action = "Changed Timeframe to"
-                
+
                 write_va_log(logger, f"[dashboard] {action} {value}", request)
-            
-        
+
 
 # helper method to get filter ids given adjacent plot regions
 def _get_filter_dict(
@@ -681,35 +742,36 @@ def _get_filter_dict(
     search_terms=[],
     locations=None,
     location_types=None,
-    restrictions=[]
+    restrictions=[],
 ):
 
     filter_df = va_df.copy()
     granularity = INITIAL_GRANULARITY
     plot_ids, plot_regions = list(), list()
-    
-    filter_dict = {
 
-        "geo_filter": any(map(lambda x: len(x) > 0, [restrictions, selected_json, search_terms])),
+    filter_dict = {
+        "geo_filter": any(
+            map(lambda x: len(x) > 0, [restrictions, selected_json, search_terms])
+        ),
         "search_filter": (len(search_terms) > 0),
         "plot_regions": [],
         "chosen_region": "all",
         "ids": [],
         "plot_ids": [],
     }
-    
+
     if filter_dict["geo_filter"]:
         # first, check if geo filter is for location restrictions
         if len(restrictions) > 0:
             # TODO: make this work for more than one assigned region
-            granularity = locations.get(restrictions[0]['name'], granularity)
+            granularity = locations.get(restrictions[0]["name"], granularity)
             # no need to filter data, as that's already done in load_data
             chosen_region = restrictions[0]
-            
-            location_obj = Location.objects.get(pk=chosen_region['id'])
+
+            location_obj = Location.objects.get(pk=chosen_region["id"])
             # if assigned to a POI (i.e. lowest level of location hierarchy) move one level up
-            #TODO: make this more generic to handle other location types
-            if location_obj.location_type == 'facility':
+            # TODO: make this more generic to handle other location types
+            if location_obj.location_type == "facility":
                 # ancestors returned in descending order
                 location_obj = location_obj.get_ancestors().last()
                 chosen_region = location_obj.name
@@ -718,9 +780,8 @@ def _get_filter_dict(
             plot_regions.append(chosen_region)
 
             plot_ids = filter_df.index.tolist()
-            filter_dict["chosen_region"] = chosen_region['name']
-            
-            
+            filter_dict["chosen_region"] = chosen_region["name"]
+
         # next, check if user searched anything. If yes, use that as filter.
         if search_terms is not None:
             if filter_dict["search_filter"]:
@@ -738,10 +799,10 @@ def _get_filter_dict(
             granularity = locations.get(chosen_regions[-1], granularity)
             filter_df = filter_df[filter_df[granularity].isin(set(chosen_regions))]
             filter_dict["chosen_region"] = chosen_regions[0]
-    
+
         # get all adjacent regions (siblings) to chosen region(s) for plotting. Dont run when user has geo restrictions
         if len(restrictions) == 0:
-            
+
             # get parent location type from current granularity
             parent_location_type = shift_granularity(
                 granularity, location_types, move_up=True
@@ -749,7 +810,9 @@ def _get_filter_dict(
 
             for parent_name in filter_df[parent_location_type].unique():
                 # get ids of vas in parent region
-                va_ids = va_df[va_df[parent_location_type] == parent_name].index.tolist()
+                va_ids = va_df[
+                    va_df[parent_location_type] == parent_name
+                ].index.tolist()
                 plot_ids = plot_ids + va_ids
                 location_object = Location.objects.get(name=parent_name)
                 children = location_object.get_children()
@@ -830,7 +893,7 @@ def get_metric_display_names(map_metrics):
     [
         Output(component_id="view_level", component_property="options"),
         Output(component_id="view_level", component_property="disabled"),
-        #Output(component_id="view_label", component_property="className"),
+        # Output(component_id="view_label", component_property="className"),
     ],
     [
         Input(component_id="filter_dict", component_property="data"),
@@ -841,23 +904,23 @@ def update_view_options(filter_dict, location_types, **kwargs):
     if filter_dict is not None:
 
         # only activate when user is zoomed out and hasn't searched for anything
-        disable = (filter_dict["geo_filter"] or filter_dict["search_filter"])
+        disable = filter_dict["geo_filter"] or filter_dict["search_filter"]
         if not disable:
             view_options = location_types
-           # label_class = "input-label"
+        # label_class = "input-label"
         else:
             view_options = []
-            #label_class = "input-label-disabled"
+            # label_class = "input-label-disabled"
         options = [{"label": o.capitalize(), "value": o} for o in view_options]
-        return options, disable #, label_class
+        return options, disable  # , label_class
 
 
 # ====================Map Logic===================================#
 @app.callback(
-#      [
-        Output(component_id="choropleth-container", component_property="children"),
-#        Output(component_id="bounds", component_property="children")
-#        ],
+    #      [
+    Output(component_id="choropleth-container", component_property="children"),
+    #        Output(component_id="bounds", component_property="children")
+    #        ],
     [
         Input(component_id="va_data", component_property="data"),
         Input(component_id="timeframe", component_property="value"),
@@ -876,7 +939,7 @@ def update_choropleth(
     filter_dict=None,
     geojson=GEOJSON,
     zoom_in=False,
-    **kwargs
+    **kwargs,
 ):
 
     # first, see which input triggered update. If granularity change, log the new value
@@ -884,7 +947,7 @@ def update_choropleth(
     trigger = context.triggered[0]
     if trigger["prop_id"].split(".")[0] == "view_level":
         log_callback_trigger(LOGGER, dash.callback_context, kwargs["request"])
-        
+
     figure = go.Figure()
     config = None
     if va_data is not None:
@@ -895,7 +958,7 @@ def update_choropleth(
         granularity = INITIAL_GRANULARITY
         location_types = location_types
         include_no_datas = True
-#        ret_val = dict()
+        #        ret_val = dict()
         border_thickness = 0.25  # thickness of borders on map
         # name of column to plot
         data_value = (
@@ -916,11 +979,11 @@ def update_choropleth(
                 # geo_filter is true if user clicked on map or searches for location
                 zoom_in = filter_dict["geo_filter"]
                 plot_regions = filter_dict["plot_regions"]
-                
-                # filter geojson to match plotting regions, stop update if regions are empty, No Data 
+
+                # filter geojson to match plotting regions, stop update if regions are empty, No Data
                 if len(plot_regions) == 0 and zoom_in:
                     raise dash.exceptions.PreventUpdate
-                
+
                 plot_data = plot_data.loc[filter_dict["ids"]["valid"], :]
                 # only proceed with filter if remaining data after filter
                 if plot_data.size > 0:
@@ -932,7 +995,8 @@ def update_choropleth(
                         )
 
                         plot_geos = [
-                            g for g in geojson["features"]
+                            g
+                            for g in geojson["features"]
                             if g["properties"]["area_name"] in plot_regions
                         ]
                         chosen_region = plot_data[granularity].unique()[0]
@@ -974,18 +1038,13 @@ def update_choropleth(
                 include_no_datas = True
             # if user has not chosen a view level or user is zooming in, default to granularity
             view_level = granularity if len(view_level) == 0 or zoom_in else view_level
-            
+
             # get map tooltips to match view level (disstrict or province)
             map_df = generate_map_data(
-                plot_data,
-                plot_geos,
-                view_level,
-                zoom_in,
-                cod_type,
-                include_no_datas,
+                plot_data, plot_geos, view_level, zoom_in, cod_type, include_no_datas,
             )
-            
-                # Set plot title to Total VAs if cod_type=='all'
+
+            # Set plot title to Total VAs if cod_type=='all'
             cod_title = "Total VAs" if cod_type == "all" else cod_type.capitalize()
 
             highlight_region = map_df.shape[0] == 1
@@ -1008,9 +1067,7 @@ def update_choropleth(
                     ],  # line markers between states
                     marker_line_width=border_thickness,
                     colorbar=dict(
-                        title="{}<br>by {}".format(
-                            cod_title, view_level.capitalize()
-                        ),
+                        title="{}<br>by {}".format(cod_title, view_level.capitalize()),
                         thicknessmode="fraction",
                         thickness=0.03,
                         lenmode="fraction",
@@ -1032,16 +1089,15 @@ def update_choropleth(
             # set a fixed scale for zero data
             if plot_data.size == 0:
                 figure.update_traces(
-                    zmin=0,
-                    zmax=8,
+                    zmin=0, zmax=8,
                 )
             # additional styling
-            config = LOOKUP['graph_config']
+            config = LOOKUP["graph_config"]
             # if geo restrictions in place, disable clicking
             if kwargs["user"].location_restrictions.exists():
                 config["scrollZoom"] = False
                 config["showAxisDragHandles"] = False
-                    
+
             figure.update_geos(
                 fitbounds="locations",
                 visible=True,
@@ -1052,9 +1108,9 @@ def update_choropleth(
                 landcolor="rgb(250,250,248)",
                 framewidth=0,
             )
-    
+
     return_value = dcc.Graph(id="choropleth", figure=figure, config=config)
-    return return_value#, json.dumps(ret_val)
+    return return_value  # , json.dumps(ret_val)
 
 
 # ==========Helper method to plot adjacent regions on map =====#
@@ -1217,35 +1273,60 @@ def update_callouts(
             coverage = "{}%".format(np.round(100 * regions_covered / total_regions, 0))
 
     return [
-        make_card(coded_vas, header="Coded VAs", tooltip="# of VAs with COD assignments in chosen region and time period"),
-        make_card(uncoded_vas, header="Uncoded VAs", tooltip="# of VAs in system missing COD assignments in chosen region and time period"),
-        make_card(active_facilities, header="Active Facilities", tooltip="# of facilities that have submitted VAs in chosen region and time period"),
+        make_card(
+            coded_vas,
+            header="Coded VAs",
+            tooltip="# of VAs with COD assignments in chosen region and time period",
+        ),
+        make_card(
+            uncoded_vas,
+            header="Uncoded VAs",
+            tooltip="# of VAs in system missing COD assignments in chosen region and time period",
+        ),
+        make_card(
+            active_facilities,
+            header="Active Facilities",
+            tooltip="# of facilities that have submitted VAs in chosen region and time period",
+        ),
         # TODO: uncomment this once field worker calculation is possible
         # make_card(num_field_workers, header="Field Workers", tooltip="# of Field Workers that have submitted VAs in chosen region and time period"),
-        make_card(coverage, header="Region Representation", tooltip="% of region type with data within surrounding geography type - ie. Facilities reporting data within District", style={"width": "225px"}),
+        make_card(
+            coverage,
+            header="Region Representation",
+            tooltip="% of region type with data within surrounding geography type - ie. Facilities reporting data within District",
+            style={"width": "225px"},
+        ),
     ]
 
 
 # build a calloutbox with specific value
 # colors: primary, secondary, info, success, warning, danger, light, dark
 def make_card(
-    value, header=None, description="", tooltip="", color="light", inverse=False, style=None
+    value,
+    header=None,
+    description="",
+    tooltip="",
+    color="light",
+    inverse=False,
+    style=None,
 ):
     card_content = []
     if header is not None:
         card_id = header.replace(" ", "")
-        card_content.append(dbc.CardHeader([
-            header,
-            html.Span(
-                html.Span(className="fas fa-info-circle"),
-                style={"margin-left": "5px", "color": "rgba(75,75,75,0.5)"},
-                id=f"{card_id}-tooltip-target"
-            ),
-            dbc.Tooltip(
-                tooltip,
-                target=f"{card_id}-tooltip-target",
-            ),
-        ], style={"padding": ".5rem"}))
+        card_content.append(
+            dbc.CardHeader(
+                [
+                    header,
+                    html.Span(
+                        html.Span(className="fas fa-info-circle"),
+                        style={"margin-left": "5px", "color": "rgba(75,75,75,0.5)"},
+                        id=f"{card_id}-tooltip-target",
+                    ),
+                    dbc.Tooltip(tooltip, target=f"{card_id}-tooltip-target",),
+                ],
+                style={"padding": ".5rem"},
+            )
+        )
     body = dbc.CardBody(
         [
             html.H3(value, className="card-title"),
@@ -1289,6 +1370,7 @@ def demographic_plot(va_data, timeframe, filter_dict=None, **kwargs):
             log_callback_trigger(LOGGER, dash.callback_context, kwargs["request"])
     return dcc.Graph(id="demos_plot", figure=figure, config=LOOKUP["chart_config"])
 
+
 # =========Cause of Death Plot Logic============================================#
 @app.callback(
     Output(component_id="cod-container", component_property="children"),
@@ -1301,8 +1383,15 @@ def demographic_plot(va_data, timeframe, filter_dict=None, **kwargs):
         Input(component_id="filter_dict", component_property="data"),
     ],
 )
-
-def cod_plot(va_data, timeframe, factor="Overall", cod_groups="All CODs", N=10, filter_dict=None, **kwargs):
+def cod_plot(
+    va_data,
+    timeframe,
+    factor="Overall",
+    cod_groups="All CODs",
+    N=10,
+    filter_dict=None,
+    **kwargs,
+):
     figure = go.Figure()
     if len(cod_groups) > 0:
         if va_data is not None:
@@ -1310,17 +1399,23 @@ def cod_plot(va_data, timeframe, factor="Overall", cod_groups="All CODs", N=10, 
             if filter_dict is not None:
                 cod = filter_dict["cod_type"]
                 plot_data = plot_data.loc[filter_dict["ids"]["valid"], :]
-            
+
                 # if no cod group filter (default), call standard cod plotting function
             cod_groups = [cod_groups] if type(cod_groups) is str else cod_groups
             figure = plotting.cod_group_plot(
-                plot_data, cod_groups, demographic=factor, N=N, chosen_cod=cod, height=560
+                plot_data,
+                cod_groups,
+                demographic=factor,
+                N=N,
+                chosen_cod=cod,
+                height=560,
             )
             log_callback_trigger(LOGGER, dash.callback_context, kwargs["request"])
         return dcc.Graph(id="cod_plot", figure=figure, config=LOOKUP["chart_config"])
     else:
         raise dash.exceptions.PreventUpdate
-        
+
+
 # ============ Trend search options ==================
 @app.callback(
     Output(component_id="ts_search", component_property="options"),
@@ -1330,52 +1425,64 @@ def cod_plot(va_data, timeframe, factor="Overall", cod_groups="All CODs", N=10, 
         Input(component_id="filter_dict", component_property="data"),
     ],
 )
-
-def update_ts_options(search_value, va_data, filter_dict=None, cod_groups=None, **kwargs):
+def update_ts_options(
+    search_value, va_data, filter_dict=None, cod_groups=None, **kwargs
+):
     if search_value and va_data:
         if not cod_groups:
             cod_groups = COD_GROUPS
-        
+
         # load cod groups
-        all_options = [(cod_group, "group") for cod_group in cod_groups.columns[2:].tolist()]
-        
+        all_options = [
+            (cod_group, "group") for cod_group in cod_groups.columns[2:].tolist()
+        ]
+
         # load unique cods in selected data
         va_data = pd.DataFrame(va_data)
         if va_data.size > 0 and filter_dict:
             valid_va_data = va_data.loc[filter_dict["ids"]["valid"], :]
             unique_cods = valid_va_data["cause"].unique().tolist()
             all_options += [(cod_name, "cod") for cod_name in unique_cods]
-            
+
         # always load all-cause option
         all_options.append(("All Causes", "All causes.all"))
-            
+
         # filter options based on search criteria
         matching_options = [
-            {"label": LOOKUP["display_names"].get(name, name.capitalize()),
-             "value": f"{name}.{type}"}
-            for name, type in all_options #if search_value.lower() in name.lower()
-        ]  
+            {
+                "label": LOOKUP["display_names"].get(name, name.capitalize()),
+                "value": f"{name}.{type}",
+            }
+            for name, type in all_options  # if search_value.lower() in name.lower()
+        ]
         return matching_options
     raise dash.exceptions.PreventUpdate
-            
+
 
 # ========= Time Series Plot Logic============================================#
 @app.callback(
-#    [
-     Output(component_id="ts-container", component_property="children"),
-#     Output(component_id="bounds", component_property="children"),
-#     ],
-    
+    #    [
+    Output(component_id="ts-container", component_property="children"),
+    #     Output(component_id="bounds", component_property="children"),
+    #     ],
     [
         Input(component_id="va_data", component_property="data"),
         Input(component_id="timeframe", component_property="value"),
         Input(component_id="group_period", component_property="value"),
         Input(component_id="filter_dict", component_property="data"),
         Input(component_id="ts_factor", component_property="value"),
-        Input(component_id="ts_search", component_property="value")
+        Input(component_id="ts_search", component_property="value"),
     ],
 )
-def trend_plot(va_data, timeframe, group_period, filter_dict=None, factor="All", search_terms=None, **kwargs):
+def trend_plot(
+    va_data,
+    timeframe,
+    group_period,
+    filter_dict=None,
+    factor="All",
+    search_terms=None,
+    **kwargs,
+):
     figure, plot_title = go.Figure(), None
     search_term_ids = {}
     if va_data is not None:
@@ -1389,8 +1496,8 @@ def trend_plot(va_data, timeframe, group_period, filter_dict=None, factor="All",
                     if type(search_terms) is str:
                         search_terms = [search_terms]
                     cod_groups = COD_GROUPS
-                    #ret_val["groups"] = cod_groups.to_json()
-                   
+                    # ret_val["groups"] = cod_groups.to_json()
+
                     for search_value in search_terms:
                         if search_value.lower().startswith("all"):
                             search_value = "All Causes.all"
@@ -1399,35 +1506,51 @@ def trend_plot(va_data, timeframe, group_period, filter_dict=None, factor="All",
                         # if keyword is a cod group, filter to only CODs in that group and only vas meeting that group's criteria
                         if key_type == "group":
                             # get ids of VAs meeting group criteria (e.g. if Neonate, subset to VAs with age < 1)
-                            criteria_ids = plotting.cod_group_data(plot_data, key, cod_groups=cod_groups).index
+                            criteria_ids = plotting.cod_group_data(
+                                plot_data, key, cod_groups=cod_groups
+                            ).index
                             # get ids of VAs meeting cod criteria (i.e. VAs with Neonatal CODs)
-                            group_cods = cod_groups[cod_groups[key]==1]["cod"].tolist()
-                            cod_ids = plot_data[plot_data["cause"].isin(group_cods)].index
+                            group_cods = cod_groups[cod_groups[key] == 1][
+                                "cod"
+                            ].tolist()
+                            cod_ids = plot_data[
+                                plot_data["cause"].isin(group_cods)
+                            ].index
                             # take intersection of criteria and cod ids to get final matching list
                             match_ids = criteria_ids.intersection(cod_ids).tolist()
-                            
+
                         elif key_type == "cod":
-                            match_ids = plot_data[plot_data["cause"] == key].index.tolist()
+                            match_ids = plot_data[
+                                plot_data["cause"] == key
+                            ].index.tolist()
                         elif key_type == "all":
                             match_ids = plot_data.index.tolist()
                         search_term_ids[search_value] = match_ids
-                    
+
                     # TODO: make this more generic (only assumes one search term)
-                    search_key = search_terms[0].split('.')[0]
-                    term_title = LOOKUP["display_names"].get(search_key,\
-                                       search_key.capitalize())
+                    search_key = search_terms[0].split(".")[0]
+                    term_title = LOOKUP["display_names"].get(
+                        search_key, search_key.capitalize()
+                    )
                     plot_title = f"{term_title} Trend by {group_period}"
-                # otherwise, check if global cod has been chosen   
+                # otherwise, check if global cod has been chosen
                 elif cod.lower() != "all":
                     cod_title = LOOKUP["display_names"].get(cod, cod)
                     plot_data = plot_data.loc[filter_dict["ids"]["valid"], :]
-                    search_term_ids[cod] = plot_data[plot_data["cause"] == cod].index.tolist()
+                    search_term_ids[cod] = plot_data[
+                        plot_data["cause"] == cod
+                    ].index.tolist()
                     plot_title = f"{cod_title} Trend by {group_period}"
-                    
+
             log_callback_trigger(LOGGER, dash.callback_context, kwargs["request"])
 
             figure = plotting.va_trend_plot(
-                plot_data, group_period, factor, title=plot_title, search_term_ids=search_term_ids, height=560
+                plot_data,
+                group_period,
+                factor,
+                title=plot_title,
+                search_term_ids=search_term_ids,
+                height=560,
             )
     return dcc.Graph(id="trend_plot", figure=figure, config=LOOKUP["chart_config"])
 


### PR DESCRIPTION
This MR adds an additional loading indicator to cover the whole row of charts in addition to the individual charts to prevent user confusion when presented with loaded but empty charts

To verify:
1. Pull, runserver, login
2. Navigate to dashboard (assumes mock data already loaded)
3. Observe lack of empty charts while data finishes loading, continue to observe when tweaking various filters on dashboard

Closes #104 