### PR TITLE
added excluded va count to dashboard header

### DIFF
--- a/va_explorer/va_analytics/utils/loading.py
+++ b/va_explorer/va_analytics/utils/loading.py
@@ -90,7 +90,7 @@ def load_va_data(user, geographic_levels=None, date_cutoff="1901-01-01"):
             "isAdult1",
             "location",
         ) \
-        .exclude(Id10023="dk") \
+        .exclude(Id10023__in=["dk", "DK"]) \
         .exclude(location__isnull=True) \
         .select_related("location") \
         .select_related("causes") \

--- a/va_explorer/va_analytics/utils/rendering.py
+++ b/va_explorer/va_analytics/utils/rendering.py
@@ -13,7 +13,7 @@ def render_update_header(va_stats):
                 submission_desc = html.P(children=[html.B("Last VA Submission: "), va_stats["last_submission"]], style={"margin-left": "10px"})
                 header.children.append(submission_desc)
             if va_stats.get("ineligible_vas", None):
-                ineligible_tooltip = "VAs excluded from dashborad due to missing location, date of death (Id10023) or both."
+                ineligible_tooltip = "VAs excluded from dashboard due to missing location, date of death (Id10023) or both."
                 ineligible_desc = html.P(
                     id="inelig-tooltip-target",
                     children=[html.B("# of Ineligible VAs: "), 

--- a/va_explorer/va_analytics/utils/rendering.py
+++ b/va_explorer/va_analytics/utils/rendering.py
@@ -1,4 +1,5 @@
 import dash_html_components as html
+import dash_bootstrap_components as dbc
 
 def render_update_header(va_stats):
     header = html.Div(className="row", id="va_stats_header", children=[])
@@ -11,4 +12,19 @@ def render_update_header(va_stats):
             if va_stats["last_submission"]:
                 submission_desc = html.P(children=[html.B("Last VA Submission: "), va_stats["last_submission"]], style={"margin-left": "10px"})
                 header.children.append(submission_desc)
+            if va_stats.get("ineligible_vas", None):
+                ineligible_tooltip = "VAs excluded from dashborad due to missing location, date of death (Id10023) or both."
+                ineligible_desc = html.P(
+                    id="inelig-tooltip-target",
+                    children=[html.B("# of Ineligible VAs: "), 
+                                va_stats["ineligible_vas"],
+                                html.Span(
+                                    className="fas fa-info-circle",
+                                    style={"margin-left": "3px", "color": "rgba(75,75,75,0.5)"}),                                
+                                dbc.Tooltip(ineligible_tooltip, target="inelig-tooltip-target")],
+                                
+                    style={"margin-left": "10px"}
+                    )
+                
+                header.children.append(ineligible_desc)
     return header

--- a/va_explorer/va_data_management/utils/loading.py
+++ b/va_explorer/va_data_management/utils/loading.py
@@ -3,7 +3,7 @@ import numpy as np
 from simple_history.utils import bulk_create_with_history
 import logging
 from django.contrib.auth import get_user_model
-
+from django.db.models import Q
 
 from va_explorer.va_data_management.models import VerbalAutopsy, VaUsername
 from va_explorer.va_data_management.utils.validate import parse_date, validate_vas_for_dashboard
@@ -190,6 +190,9 @@ def get_va_summary_stats(vas):
             stats['last_update'] =  last_update.strftime('%d %b, %Y')
         # Record latest submission date (from ODK). Column may/may not be available depending on source
         raw_submissions =  vas.values_list('submissiondate', flat=True)
+
+        # track number of ineligible VAs for dashboard
+        stats['ineligible_vas'] = vas.filter(Q(Id10023='dk') | Q(location__isnull=True)).count()
         if raw_submissions.count() > 0:
             last_submission = pd.to_datetime(raw_submissions).max()
             if not pd.isnull(last_submission):

--- a/va_explorer/va_data_management/utils/loading.py
+++ b/va_explorer/va_data_management/utils/loading.py
@@ -192,7 +192,8 @@ def get_va_summary_stats(vas):
         raw_submissions =  vas.values_list('submissiondate', flat=True)
 
         # track number of ineligible VAs for dashboard
-        stats['ineligible_vas'] = vas.filter(Q(Id10023='dk') | Q(location__isnull=True)).count()
+        stats['ineligible_vas'] = vas.filter(Q(Id10023__in=['DK','dk']) | Q(Id10023__isnull=True)|\
+         Q(location__isnull=True)).count()
         if raw_submissions.count() > 0:
             last_submission = pd.to_datetime(raw_submissions).max()
             if not pd.isnull(last_submission):


### PR DESCRIPTION
Experimented with adding as a callout box but was ultimately simpler to just tack onto header, which should look like this: 
![image](https://user-images.githubusercontent.com/55208284/127253518-56a41b34-ae3f-4584-bb8e-251b6730c129.png).
Includes a tooltip for further context. 

Now, when user first views the dashboard, the sum of Coded VAs, Uncoded VAs, and Number of Excluded VAs should equal the reported total count on the homepage. 

This helps address issue #108.