### PR TITLE
Add view_dashboard permission to field worker role

### DIFF
--- a/va_explorer/users/management/commands/initialize_groups.py
+++ b/va_explorer/users/management/commands/initialize_groups.py
@@ -26,7 +26,7 @@ GROUPS_PERMISSIONS = {
         VerbalAutopsy: ["view_verbalautopsy"],
     },
     "Field Workers": {
-        Dashboard: [],
+        Dashboard: ["view_dashboard"],
         User: [],
         VerbalAutopsy: ["view_verbalautopsy"]
     },

--- a/va_explorer/va_analytics/dash_apps/va_dashboard.py
+++ b/va_explorer/va_analytics/dash_apps/va_dashboard.py
@@ -780,7 +780,7 @@ def _get_filter_dict(
             plot_regions.append(chosen_region)
 
             plot_ids = filter_df.index.tolist()
-            filter_dict["chosen_region"] = chosen_region["name"]
+            filter_dict["chosen_region"] = chosen_region
 
         # next, check if user searched anything. If yes, use that as filter.
         if search_terms is not None:


### PR DESCRIPTION
This PR allows field workers to view the dashboard for information needs revealed in user feedback. The dashboard automatically shows just the district the field worker has access to. 

Note: according to the pre-existing TODOs, this feature will continue to only work for those with one geographic access (not a list of geographic accesses)

To test:
- Run `./manage.py inititalize_groups` to update permissions
- Run `./manage.py runserver 0.0.0.0:8000` and log in as any of the demo field worker users
- Confirm access to dashboard and default map focus to field worker's area assignment

Closes #109 