### PR TITLE
Add filters and role based name data to data management module

### DIFF
--- a/va_explorer/templates/partials/_va_table.html
+++ b/va_explorer/templates/partials/_va_table.html
@@ -5,13 +5,14 @@
     <tr>
       <th>ID</th>
       <th>Date</th>
-      <th>Interviewer</th>
+      <th>Deceased</th>
+      {% if not user.is_fieldworker %}
+        <th>Interviewer</th>
+      {% endif %}
       <th>Facility</th>
       <th>Cause</th>
-      {% if not user.is_fieldworker %}
-        <th>Warnings</th>
-        <th>Errors</th>
-      {% endif %}
+      <th>Warnings</th>
+      <th>Errors</th>
       <th>View</th>
     </tr>
   </thead>
@@ -20,13 +21,14 @@
     <tr>
       <td>{{ va.id }}</td>
       <td>{% pii_filter "Id10023" va.date %}</td>
-      <td>{% pii_filter "Id10010" va.interviewer %}</td>
+      <td>{% pii_filter "Id10017" va.deceased %}</td>
+      {% if not user.is_fieldworker %}
+        <td>{{ va.interviewer }}</td>
+      {% endif %}
       <td>{{ va.facility }}</td>
       <td>{{ va.cause }}</td>
-      {% if not user.is_fieldworker %}
-        <td>{{ va.warnings }}</td>
-        <td>{{ va.errors }}</td>
-      {% endif %}
+      <td>{{ va.warnings }}</td>
+      <td>{{ va.errors }}</td>
       <td><a class="btn btn-primary" href="{% url 'data_management:show' id=va.id %}">View</a></td>
     </tr>
     {% endfor %}

--- a/va_explorer/templates/va_data_management/index.html
+++ b/va_explorer/templates/va_data_management/index.html
@@ -8,7 +8,6 @@
 
 {% block content %}
 {% include 'partials/_va_update_stats.html' %}
-{% if not user.is_fieldworker and user.can_view_pii %}
 <form method="get">
   <div class="form-row align-items-end">
     {% crispy filterset.form %}
@@ -22,7 +21,6 @@
     {% endif %}
   </div>
 </form>
-{% endif %}
 
 <div class="row mt-4">
   {% include 'partials/_va_table.html' with va_list=object_list %}

--- a/va_explorer/templates/va_data_management/show.html
+++ b/va_explorer/templates/va_data_management/show.html
@@ -11,11 +11,9 @@
   <li class="nav-item">
     <a class="nav-link active" id="record-tab" data-toggle="tab" href="#record" role="tab" aria-controls="record" aria-selected="true">Record</a>
   </li>
-  {% if errors or warnings and not user.is_fieldworker  %}
-    <li class="nav-item">
-      <a class="nav-link" id="issues-tab" data-toggle="tab" href="#issues" role="tab" aria-controls="issues" aria-selected="false">Coding Issues</a>
-    </li>
-  {% endif %}
+  <li class="nav-item">
+    <a class="nav-link" id="issues-tab" data-toggle="tab" href="#issues" role="tab" aria-controls="issues" aria-selected="false">Coding Issues</a>
+  </li>
   {% if diffs and not user.is_fieldworker %}
     <li class="nav-item">
       <a class="nav-link" id="history-tab" data-toggle="tab" href="#history" role="tab" aria-controls="history" aria-selected="false">Change History</a>
@@ -52,43 +50,41 @@
       </table>
     </div>
   </div>
-  {% if errors or warnings and not user.is_fieldworker  %}
-    <div class="tab-pane fade" id="issues" role="tabpanel" aria-labelledby="issues-tab">
-      <div class="row mt-4">
-        {% if errors %}
-          <table class="table table-hover table-sm">
-            <thead>
-              <tr>
-                <th>{{ errors|length }} Error{{ errors|pluralize }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for error in errors %}
-                <tr><td>{{ error }}</td></tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        {% endif %}
-      </div>
-
-      {% if warnings %}
-        <div class="row mt-4">
-          <table class="table table-hover table-sm">
-            <thead>
-              <tr>
-                <th>{{ warnings|length }} Warning{{ warnings|pluralize }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for warning in warnings %}
-                <tr><td>{{ warning }}</td></tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+  <div class="tab-pane fade" id="issues" role="tabpanel" aria-labelledby="issues-tab">
+    <div class="row mt-4">
+      {% if errors %}
+        <table class="table table-hover table-sm">
+          <thead>
+            <tr>
+              <th>{{ errors|length }} Error{{ errors|pluralize }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for error in errors %}
+              <tr><td>{{ error }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
       {% endif %}
     </div>
-  {% endif %}
+
+    {% if warnings %}
+      <div class="row mt-4">
+        <table class="table table-hover table-sm">
+          <thead>
+            <tr>
+              <th>{{ warnings|length }} Warning{{ warnings|pluralize }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for warning in warnings %}
+              <tr><td>{{ warning }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% endif %}
+  </div>
 
   {% if diffs and not user.is_fieldworker  %}
     <div class="tab-pane fade" id="history" role="tabpanel" aria-labelledby="history-tab">

--- a/va_explorer/va_data_management/filters.py
+++ b/va_explorer/va_data_management/filters.py
@@ -3,7 +3,7 @@ from django import forms
 from django_filters import FilterSet, DateFilter, CharFilter, DateRangeFilter, BooleanFilter
 
 from .models import VerbalAutopsy
-
+from django.db.models import Q
 
 TRUE_FALSE_CHOICES = (
     (False, 'No'),
@@ -16,17 +16,26 @@ class DateInput(forms.DateInput):
 
 
 class VAFilter(FilterSet):
-	interviewer = CharFilter(field_name="Id10010", lookup_expr="icontains", label="Interviewer")
-	start_date = DateFilter(field_name="Id10023", lookup_expr="gte", label="Earliest Date", widget=DateInput(attrs={'class': 'datepicker'}))
-	end_date = DateFilter(field_name="Id10023", lookup_expr="lte", label="Latest Date", widget=DateInput(attrs={'class': 'datepicker'}))
-	location = CharFilter(field_name="location__name", lookup_expr="icontains", label="Facility")
-	only_errors = BooleanFilter(method="filter_errors", label="Only Errors", widget=forms.Select(choices=TRUE_FALSE_CHOICES, attrs={'class': 'custom-select'}))
+    interviewer = CharFilter(field_name="Id10010", lookup_expr="icontains", label="Interviewer")
+    deceased = CharFilter(method="filter_deceased", label="Deceased")
+    start_date = DateFilter(field_name="Id10023", lookup_expr="gte", label="Earliest Date", widget=DateInput(attrs={'class': 'datepicker'}))
+    end_date = DateFilter(field_name="Id10023", lookup_expr="lte", label="Latest Date", widget=DateInput(attrs={'class': 'datepicker'}))
+    location = CharFilter(field_name="location__name", lookup_expr="icontains", label="Facility")
+    cause = CharFilter(field_name="causes__cause", lookup_expr="icontains", label="Cause")
+    only_errors = BooleanFilter(method="filter_errors", label="Only Errors", widget=forms.Select(choices=TRUE_FALSE_CHOICES, attrs={'class': 'custom-select'}))
 
-	class Meta:
-		model = VerbalAutopsy
-		fields = []
+    class Meta:
+        model = VerbalAutopsy
+        fields = []
 
-	def filter_errors(self, queryset, name, value):
-		if value:
-			return queryset.filter(coding_issues__severity='error')
-		return queryset
+    def filter_deceased(self, queryset, name, value):
+        if value:
+            return VerbalAutopsy.objects.filter(
+                Q(Id10017__icontains=value) | Q(Id10018__icontains=value)
+            )
+        return queryset
+
+    def filter_errors(self, queryset, name, value):
+        if value:
+            return queryset.filter(coding_issues__severity='error')
+        return queryset

--- a/va_explorer/va_data_management/filters.py
+++ b/va_explorer/va_data_management/filters.py
@@ -30,9 +30,7 @@ class VAFilter(FilterSet):
 
     def filter_deceased(self, queryset, name, value):
         if value:
-            return VerbalAutopsy.objects.filter(
-                Q(Id10017__icontains=value) | Q(Id10018__icontains=value)
-            )
+            return queryset.filter(Q(Id10017__icontains=value) | Q(Id10018__icontains=value))
         return queryset
 
     def filter_errors(self, queryset, name, value):

--- a/va_explorer/va_data_management/tests/test_views.py
+++ b/va_explorer/va_data_management/tests/test_views.py
@@ -294,16 +294,17 @@ def test_field_worker_access_control():
     field_worker.save()
     field_worker_username.save()
 
-    va = VerbalAutopsyFactory.create(Id10010='Unique Value VA1', location=facility, username=field_worker_username.va_username)
-    va2 = VerbalAutopsyFactory.create(Id10010='Another Value VA2', location=facility, username='')
+    va = VerbalAutopsyFactory.create(Id10017='Unique Value VA1', Id10010='Role specific value', location=facility, username=field_worker_username.va_username)
+    va2 = VerbalAutopsyFactory.create(Id10017='Another Value VA2', location=facility, username='')
 
     client = Client()
     client.force_login(user=field_worker)
 
     response = client.get("/va_data_management/")
     assert response.status_code == 200
-    assert str(va.Id10010).encode('utf_8') in response.content
-    assert str(va2.Id10010).encode('utf_8') not in response.content
+    assert str(va.Id10017).encode('utf_8') in response.content
+    assert str(va.Id10010).encode('utf_8') not in response.content  # field workers see deceased, not interviewer
+    assert str(va2.Id10017).encode('utf_8') not in response.content
 
     response = client.get(f"/va_data_management/show/{va.id}")
     assert response.status_code == 200

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -29,8 +29,14 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
         # Restrict to VAs this user can access and prefetch related for performance
         queryset = self.request.user.verbal_autopsies().prefetch_related("location", "causes", "coding_issues").order_by("id")
         self.filterset = VAFilter(data=self.request.GET or None, queryset=queryset)
-        if self.request.user.is_fieldworker():
+        if self.request.user.is_fieldworker:
             del self.filterset.form.fields['interviewer']
+
+        # Don't allow search based on fields the user can't see anyway
+        if not self.request.user.can_view_pii:
+            del self.filterset.form.fields['deceased']
+            del self.filterset.form.fields['start_date']
+            del self.filterset.form.fields['end_date']
 
         query_dict = self.request.GET.dict()
         query_keys = [k for k in query_dict if k != 'csrfmiddlewaretoken']

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -28,16 +28,10 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
     def get_queryset(self):
         # Restrict to VAs this user can access and prefetch related for performance
         queryset = self.request.user.verbal_autopsies().prefetch_related("location", "causes", "coding_issues").order_by("id")
-        # TODO: For now, we are not displaying the filters for the Field Worker on the VA index page,
-        # since many do not apply to them. This prevents data passed through the params from being
-        # passed to the VAFilter
-        # Also hide filter if the user cannot view PII since the filterable fields contain PII.
-        if self.request.user.is_fieldworker() or not self.request.user.can_view_pii:
-            self.filterset = VAFilter(data=None, queryset=queryset)
+        self.filterset = VAFilter(data=self.request.GET or None, queryset=queryset)
+        if self.request.user.is_fieldworker():
+            del self.filterset.form.fields['interviewer']
 
-        # do the filtering thing
-        else:
-            self.filterset = VAFilter(data=self.request.GET or None, queryset=queryset)
         query_dict = self.request.GET.dict()
         query_keys = [k for k in query_dict if k != 'csrfmiddlewaretoken']
         if len(query_keys) > 0:
@@ -50,16 +44,27 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
         context = super().get_context_data(**kwargs)
 
         context["filterset"] = self.filterset
-        #parse_date(va.Id10023)
-        context['object_list'] = [{
-            "id": va.id,
-            "interviewer": va.Id10010,
-            "date":  va.Id10023 if (va.Id10023 != 'dk') else "Unknown", #django stores the date in yyyy-mm-dd
-            "facility": va.location.name if va.location else "",
-            "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
-            "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
-            "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
-        } for va in context['object_list']]
+        if not self.request.user.is_fieldworker():
+            context['object_list'] = [{
+                "id": va.id,
+                "deceased": f"{va.Id10017} {va.Id10018}",
+                "interviewer": va.Id10010,
+                "date":  va.Id10023 if (va.Id10023 != 'dk') else "Unknown", #django stores the date in yyyy-mm-dd
+                "facility": va.location.name if va.location else "",
+                "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
+                "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
+                "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
+            } for va in context['object_list']]
+        else:
+            context['object_list'] = [{
+                "id": va.id,
+                "deceased": f"{va.Id10017} {va.Id10018}",
+                "date":  va.Id10023 if (va.Id10023 != 'dk') else "Unknown", #django stores the date in yyyy-mm-dd
+                "facility": va.location.name if va.location else "",
+                "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
+                "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
+                "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
+            } for va in context['object_list']]
 
         context.update(get_va_summary_stats(self.filterset.qs))
 


### PR DESCRIPTION
This PR adds:
- Ability to filter data mgmt by cause of death
- Ability to view, and filter by name of interviewer for non field worker roles
- Ability to view, and filter by name of deceased for all roles

Tangentially, it changes views so that field workers now have the ability to view VA warnings and errors

To test:
1. Login as a non field worker role and navigate to the data mgmt module
2. Observe filter form fields for cause of death, name of interviewer, and name of deceased
3. Attempt to filter by any or all of these properties and confirm expected returned VA results
4. Repeat step 1 for a field worker role user
5. Observe absense of interviewer from previously mentioned fields
6. Bonus: Confirm that querying a redacted (you as dev know what field contains but user doesn't) field doesn't return data for known (to you as dev) data 

Closes #133