### PR TITLE
Date-Fixes-v2

### DIFF
--- a/va_explorer/home/tests/test_views.py
+++ b/va_explorer/home/tests/test_views.py
@@ -1,8 +1,11 @@
 import pytest
 from django.test import Client
 from va_explorer.users.models import User
+from datetime import date
 from va_explorer.va_data_management.models import VerbalAutopsy
 from va_explorer.tests.factories import VerbalAutopsyFactory, LocationFactory
+from dateutil.relativedelta import relativedelta
+
 
 pytestmark = pytest.mark.django_db
 
@@ -10,7 +13,8 @@ pytestmark = pytest.mark.django_db
 def test_index(user: User):
     client = Client()
     client.force_login(user=user)
-    va = VerbalAutopsyFactory.create()
+    today = date.today()
+    va = VerbalAutopsyFactory.create(submissiondate=today, Id10023=today)
     response = client.get("/")
     assert response.status_code == 200
     assert response.context['vas_collected_24_hours'] == 1
@@ -26,8 +30,9 @@ def test_index(user: User):
     assert response.context['vas_uncoded_1_month'] == 1
     assert response.context['vas_uncoded_overall'] == 1
     assert len(response.context['issue_list']) == 1
-    assert response.context['issue_list'][0]['name'] == va.Id10007
+    assert va.Id10017 in response.context['issue_list'][0]['name']
     assert response.context['additional_issues'] == 0
+
 
 # Get the about page and make sure it returns successfully
 def test_about(user: User):

--- a/va_explorer/home/views.py
+++ b/va_explorer/home/views.py
@@ -6,10 +6,13 @@ from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
 import numpy as np
 import pandas as pd
+from pandas import to_datetime as to_dt
+from django.db.models import F
 # TODO: We're using plotly here since it's already included in the project, but there may be slimmer options
 import plotly.offline as opy
 import plotly.graph_objs as go
 from va_explorer.va_data_management.utils.loading import get_va_summary_stats
+from va_explorer.va_data_management.utils.validate import parse_date
 
 # Simple helper function for creating the plotly graphs used on the home page
 def graph(x, y):
@@ -27,76 +30,109 @@ class Index(CustomAuthMixin, TemplateView):
         context = super().get_context_data(**kwargs)
 
         user = self.request.user
-        user_vas = user.verbal_autopsies()
-        location_restrictions = user.location_restrictions
+        # determine which name column to pull in based on user role
+        name_field = "Id10007" if user.is_fieldworker() else "Id10010"
         today = date.today()
-
+        start_month = to_dt(date(today.year - 1, today.month, 1))
+        location_restrictions = user.location_restrictions
         if location_restrictions.count() > 0:
             context['locations'] = ', '.join([location.name for location in location_restrictions.all()])
         else:
             context['locations'] = 'All Regions' 
-        
-        context.update(get_va_summary_stats(user_vas))
-        # Load the VAs that are collected over various periods of time
-        # TODO: We're using date imported, but might be more appropriate to use date collected? If updating
-        # this, look for all references to 'created'
-        vas_24_hours = user_vas.filter(created__gte=today)
-        vas_1_week = user_vas.filter(created__gte=today - timedelta(days=7))
-        vas_1_month = user_vas.filter(created__gte=today - relativedelta(months=1))
-        vas_overall = user_vas.order_by('id')
+        # NOTE: using SUBMISSIONDATE to drive stats/views. To change this, change all references to submissiondate
+        user_vas = user.verbal_autopsies()
+        if user_vas.count() > 0:
+            va_df = pd.DataFrame(user_vas\
+                .only("id","Id10023","location","submissiondate","created",name_field) \
+                .select_related("location") \
+                .select_related("causes") \
+                .values("id","Id10023", "created",date=F("submissiondate"),
+                    name=F(name_field),facility=F("location__name"),cause=F("causes__cause"),
+                ))
 
-        
-        # VAs collected in the past 24 hours, 1 week, and 1 month
-        context['vas_collected_24_hours'] = vas_24_hours.count()
-        context['vas_collected_1_week'] = vas_1_week.count()
-        context['vas_collected_1_month'] = vas_1_month.count()
-        context['vas_collected_overall'] = vas_overall.count()
-        # VAs successfully coded in the past 24 hours, 1 week, and 1 month
-        context['vas_coded_24_hours'] = vas_24_hours.filter(causes__isnull=False).count()
-        context['vas_coded_1_week'] = vas_1_week.filter(causes__isnull=False).count()
-        context['vas_coded_1_month'] = vas_1_month.filter(causes__isnull=False).count()
-        context['vas_coded_overall'] = vas_overall.filter(causes__isnull=False).count()
-        # VAs not able to be coded in the past 24 hours, 1 week, and 1 month
-        context['vas_uncoded_24_hours'] = context['vas_collected_24_hours'] - context['vas_coded_24_hours']
-        context['vas_uncoded_1_week'] = context['vas_collected_1_week'] - context['vas_coded_1_week']
-        context['vas_uncoded_1_month'] = context['vas_collected_1_month'] - context['vas_coded_1_month']
-        context['vas_uncoded_overall'] = context['vas_collected_overall'] - context['vas_coded_overall']
+            # clean date fields - strip timezones from submissiondate and created dates
+            va_df["date"] = to_dt(to_dt(va_df["date"]).dt.date)
+            va_df["created"] = to_dt(to_dt(va_df["created"]).dt.date)
+            va_df["Id10023"] = to_dt(va_df["Id10023"], errors="coerce")
+            va_df["yearmonth"] = va_df["date"].dt.strftime("%Y-%m")
+            
+            context.update(get_va_summary_stats(user_vas))
+            # Load the VAs that are collected over various periods of time
+            today = to_dt(date.today())
 
-        # Graphs of the past 12 months, not including this month (including the current month will almost
-        # always show the month with artificially low numbers)
-        start_month = date(today.year - 1, today.month, 1)
-        months = [start_month + relativedelta(months=i) for i in range(12)]
-        x = [month.strftime('%b') for month in months]
+            vas_24_hours = va_df[va_df["date"] == today].index
+            vas_1_week = va_df[va_df['date'] >= (today - timedelta(days=7))].index
+            vas_1_month = va_df[va_df['date'] >= (today - relativedelta(months=1))].index
+            vas_overall = va_df.sort_values(by="id").index
 
-        # Collected; this query groups by month (cast to a date from a datetime) and returns the counts by month
-        collected_counts = user_vas.filter(created__gte=start_month).annotate(month=TruncMonth('created')).values('month').annotate(count=Count('*'))
-        collected_by_month = {entry['month'].date():entry['count'] for entry in collected_counts}
-        y_collected = [collected_by_month.get(month, 0) for month in months]
-        context['graph_collected'] = graph(x, y_collected)
+            # VAs collected in the past 24 hours, 1 week, and 1 month
+            context['vas_collected_24_hours'] = len(vas_24_hours)
+            context['vas_collected_1_week'] = len(vas_1_week)
+            context['vas_collected_1_month'] = len(vas_1_month)
+            context['vas_collected_overall'] = len(vas_overall)
+            # VAs successfully coded in the past 24 hours, 1 week, and 1 month        
+            context['vas_coded_24_hours'] = va_df.loc[vas_24_hours,:].query("cause == cause").shape[0]
+            context['vas_coded_1_week'] = va_df.loc[vas_1_week,:].query("cause == cause").shape[0]
+            context['vas_coded_1_month'] = va_df.loc[vas_1_month,:].query("cause == cause").shape[0]
+            context['vas_coded_overall'] = va_df.loc[vas_overall,:].query("cause == cause").shape[0]
+            # VAs not able to be coded in the past 24 hours, 1 week, and 1 month
+            context['vas_uncoded_24_hours'] = context['vas_collected_24_hours'] - context['vas_coded_24_hours']
+            context['vas_uncoded_1_week'] = context['vas_collected_1_week'] - context['vas_coded_1_week']
+            context['vas_uncoded_1_month'] = context['vas_collected_1_month'] - context['vas_coded_1_month']
+            context['vas_uncoded_overall'] = context['vas_collected_overall'] - context['vas_coded_overall']
 
-        # Coded; same query as above, just filtered by whether the va has been coded
-        coded_counts = user_vas.filter(created__gte=start_month, causes__isnull=False).annotate(month=TruncMonth('created')).values('month').annotate(count=Count('*'))
-        coded_by_month = {entry['month'].date():entry['count'] for entry in coded_counts}
-        y_coded = [coded_by_month.get(month, 0) for month in months]
-        context['graph_coded'] = graph(x, y_coded)
+            # Graphs of the past 12 months, not including this month (current month will almost
+            # always show the month with artificially low numbers)
+            plot_df = (pd.DataFrame({'month':[start_month + relativedelta(months=i) for i in range(12)]})
+                        .assign(month_num = lambda df: df['month'].dt.month)
+                )
 
-        # Uncoded; just take the difference between the two previous queries
-        context['graph_uncoded'] = graph(x, np.subtract(y_collected, y_coded))
+            months = [start_month + relativedelta(months=i) for i in range(12)]
+            x = [month.strftime('%b') for month in months]
+            plot_df = pd.DataFrame({'yearmonth': [month.strftime('%Y-%m') for month in months], 'x': x})
 
-        # List the VAs that need attention; requesting certain fields and prefetching makes this more efficient
-        vas_to_address = vas_overall.only('id', 'location_id', 'Id10007', 'Id10023').filter(causes__isnull=True).prefetch_related("causes", "coding_issues", "location")[:10]
-        context['issue_list'] = [{
-            "id": va.id,
-            "name": va.Id10007,
-            "date":  va.Id10023 if (va.Id10023 != 'dk') else "Unknown", #django stores the date in yyyy-mm-dd
-            "facility": va.location.name if va.location else "",
-            "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
-            "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
-            "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
-        } for va in vas_to_address]
+            # Collected; total VAs by month
+            plot_df = plot_df.merge(va_df.query("date >= @start_month").groupby("yearmonth")["id"].count().rename("y_collected").reset_index(), how="left").fillna(0)
+            context['graph_collected'] = graph(plot_df['x'], plot_df['y_collected'])
 
-        # If there are more than 10 show a link to where the rest can be seen
-        context['additional_issues'] = max(context['vas_uncoded_overall'] - 10, 0)
+            # Coded; same query as above, just filtered by whether the va has been coded
+            plot_df = plot_df.merge(va_df.query("date >= @start_month & cause==cause").groupby("yearmonth")["id"].count().rename("y_coded").reset_index(), how="left").fillna(0)
+            # y_coded = va_df.query().groupby("yearmonth")["id"].count().values
+            #y_coded = [coded_by_month.get(month, 0) for month in months]
+            context['graph_coded'] = graph(plot_df['x'], plot_df['y_coded'])
+
+            # Uncoded; just take the difference between the two previous queries
+            context['graph_uncoded'] = graph(plot_df['x'], (plot_df['y_collected'] - plot_df['y_coded']))
+
+            # List the VAs that need attention; requesting certain fields and prefetching makes this more efficient
+            vas_to_address = user_vas.only('id', 'location_id', 'Id10007', 'Id10010', 'Id10017',
+                'Id10018', 'submissiondate', 'Id10023').filter(causes__isnull=True)[:10].prefetch_related("causes", "coding_issues", "location")
+
+            context['issue_list'] = [{
+                "id": va.id,
+                "deceased": f"{va.Id10017} {va.Id10018}", 
+                "interviewer": va.Id10010,
+                "date":  parse_date(va.submissiondate) if (va.submissiondate != 'dk') else "Unknown", #django stores the date in yyyy-mm-dd
+                "facility": va.location.name if va.location else "",
+                "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
+                "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
+                "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
+            } for va in vas_to_address]
+
+            # If there are more than 10 show a link to where the rest can be seen
+            context['additional_issues'] = max(context['vas_uncoded_overall'] - 10, 0)
+        # NO VAS FOUND - RETURN EMPTY STATS
+        else:
+            # empty stats
+            for va_type in ['collected', 'coded', 'uncoded']:
+                for va_time_period in ['24_hours', '1_week', '1_mont',  'overall']:
+                    context[f"vas_{va_type}_{va_time_period}"] = 0
+            # empty graphs
+            months = [start_month + relativedelta(months=i) for i in range(12)]
+            x = [month.strftime('%b') for month in months]
+            for va_type in ['collected', 'coded', 'uncoded']: 
+                context[f"graph_{va_type}"] = graph(x, np.repeat(0, len(x)))
+            context['issue_list'] = []
 
         return context
 

--- a/va_explorer/templates/home/index.html
+++ b/va_explorer/templates/home/index.html
@@ -82,7 +82,7 @@
         {% include 'partials/_va_table.html' with va_list=issue_list %}
         {% if additional_issues > 0 %}<p>There are <a href="/va_data_management/?only_errors=True" id="additional_issues">{{ additional_issues }} additional issues</a> not listed here</p>{% endif %}
       {% else %}
-        <p>Excellent, no coding issues found!</p>
+        <p>No coding issues found</p>
       {% endif %}
     {% endif %}
   </div>

--- a/va_explorer/templates/partials/_va_table.html
+++ b/va_explorer/templates/partials/_va_table.html
@@ -4,15 +4,17 @@
   <thead>
     <tr>
       <th>ID</th>
-      <th>Date</th>
+      <th>Submission Date</th>
       <th>Deceased</th>
       {% if not user.is_fieldworker %}
         <th>Interviewer</th>
       {% endif %}
       <th>Facility</th>
       <th>Cause</th>
-      <th>Warnings</th>
-      <th>Errors</th>
+      {% if not user.is_fieldworker %}
+        <th>Warnings</th>
+        <th>Errors</th>
+      {% endif %}
       <th>View</th>
     </tr>
   </thead>
@@ -20,15 +22,17 @@
     {% for va in va_list %}
     <tr>
       <td>{{ va.id }}</td>
-      <td>{% pii_filter "Id10023" va.date %}</td>
+      <td>{% pii_filter "submissiondate" va.date %}</td>
       <td>{% pii_filter "Id10017" va.deceased %}</td>
       {% if not user.is_fieldworker %}
         <td>{{ va.interviewer }}</td>
       {% endif %}
       <td>{{ va.facility }}</td>
       <td>{{ va.cause }}</td>
-      <td>{{ va.warnings }}</td>
-      <td>{{ va.errors }}</td>
+      {% if not user.is_fieldworker %}
+        <td>{{ va.warnings }}</td>
+        <td>{{ va.errors }}</td>
+      {% endif %}
       <td><a class="btn btn-primary" href="{% url 'data_management:show' id=va.id %}">View</a></td>
     </tr>
     {% endfor %}

--- a/va_explorer/va_data_management/management/commands/randomize_va_dates.py
+++ b/va_explorer/va_data_management/management/commands/randomize_va_dates.py
@@ -28,6 +28,6 @@ class Command(BaseCommand):
         dates_list.sort()
         for va, new_date in zip(VerbalAutopsy.objects.all(), dates_list):
             # Set Id10023 and created and updated all to same date
-            va.Id10023 = va.created = va.updated = new_date
+            va.Id10023 = va.created = va.updated = va.submissiondate = new_date 
             va.skip_history_when_saving = True
             va.save()

--- a/va_explorer/va_data_management/tests/test_views.py
+++ b/va_explorer/va_data_management/tests/test_views.py
@@ -154,7 +154,7 @@ def test_save_with_invalid_date_format(user: User):
     va = VerbalAutopsyFactory.create(Id10017='Victim name', Id10010='Interviewer name')
     assert va.history.count() == 1
     new_name = "Updated Example Name"
-    response = client.post(f"/va_data_management/edit/{va.id}", { "Id10010": new_name, "Id10023":"21-03-01", "Id10058": va.location.name })
+    response = client.post(f"/va_data_management/edit/{va.id}", { "Id10010": new_name, "Id10023":"this is not a date 1234" })
     assert response.status_code == 200
 
 # Verify save access is restricted
@@ -294,17 +294,16 @@ def test_field_worker_access_control():
     field_worker.save()
     field_worker_username.save()
 
-    va = VerbalAutopsyFactory.create(Id10017='Unique Value VA1', Id10010='Role specific value', location=facility, username=field_worker_username.va_username)
-    va2 = VerbalAutopsyFactory.create(Id10017='Another Value VA2', location=facility, username='')
+    va = VerbalAutopsyFactory.create(Id10010='Unique Value VA1', location=facility, username=field_worker_username.va_username)
+    va2 = VerbalAutopsyFactory.create(Id10010='Another Value VA2', location=facility, username='')
 
     client = Client()
     client.force_login(user=field_worker)
 
     response = client.get("/va_data_management/")
     assert response.status_code == 200
-    assert str(va.Id10017).encode('utf_8') in response.content
-    assert str(va.Id10010).encode('utf_8') not in response.content  # field workers see deceased, not interviewer
-    assert str(va2.Id10017).encode('utf_8') not in response.content
+    assert str(va.Id10010).encode('utf_8') in response.content
+    assert str(va2.Id10010).encode('utf_8') not in response.content
 
     response = client.get(f"/va_data_management/show/{va.id}")
     assert response.status_code == 200

--- a/va_explorer/va_data_management/utils/loading.py
+++ b/va_explorer/va_data_management/utils/loading.py
@@ -117,6 +117,12 @@ def load_records_from_dataframe(record_df, random_locations=False, debug=True):
             logger.info(f"va_id: {va_id} - Parsed {parsed_date} for Date of Death from {va.Id10023}") 
         va.Id10023 = parsed_date
 
+        # Try to parse submission date as as datetime. Otherwise, record string and add record issue during validation
+        parsed_sub_date = parse_date(va.submissiondate, strict=False)
+        if logger:
+            logger.info(f"va_id: {va_id} - Parsed {parsed_sub_date} as Submission Date from {va.submissiondate}") 
+        va.submissiondate = parsed_sub_date
+
         # Try mapping va location to known db location. If not possible, set to null location
         
         # if random_locations, assign random field worker to VA which can be used to determine location.

--- a/va_explorer/va_data_management/utils/validate.py
+++ b/va_explorer/va_data_management/utils/validate.py
@@ -9,6 +9,7 @@ from va_explorer.va_data_management.models import CauseCodingIssue
 from va_explorer.va_data_management.models import VaUsername
 from va_explorer.va_data_management.utils.location_assignment import assign_va_location
 from config.settings.base import DATE_FORMATS
+from pandas import to_datetime
 
 
 def validate_vas_for_dashboard(verbal_autopsies):
@@ -106,15 +107,18 @@ def parse_date(date_str, formats=DATE_FORMATS.keys(), strict=False, return_forma
                     return datetime.strptime(date_str, fmt).date().strftime(return_format)
                 except ValueError:
                     pass
-            # if we get here, all hardcoded patterns failed - try timestamp regex as last resort
+            # if we get here, all hardcoded patterns failed - try timestamp regex 
             # if time time separator T present, strip out time and pull solely date
             if len(re.findall("\dT\d", date_str)) > 0:
                 return re.split("T\d", date_str)[0]
+            # if regex patterns not found, try pandas's to_datetime util as last resort
             else:
-                # if we get here, couldn't parse the date. If strict, raise error. Otherwise, return original string
-                if strict:
-                    raise ValueError(f'no valid date format found for date string {date_str}')
-                else:
-                    return str(date_str)
+                try:
+                    return to_datetime(date_str).date().strftime(return_format)
+                except:
+                    # if we get here, couldn't parse the date. If strict, raise error. Otherwise, return original string
+                    if strict:
+                        raise ValueError(f'no valid date format found for date string {date_str}')
+                    else:
+                        return str(date_str)
     return 'dk'
-        

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -15,7 +15,7 @@ from va_explorer.va_data_management.models import VerbalAutopsy
 from va_explorer.va_data_management.tasks import run_coding_algorithms
 from va_explorer.va_data_management.utils.loading import get_va_summary_stats
 from va_explorer.va_logs.logging_utils import write_va_log
-from va_explorer.va_data_management.utils.validate import validate_vas_for_dashboard
+from va_explorer.va_data_management.utils.validate import validate_vas_for_dashboard, parse_date
 
 
 LOGGER = logging.getLogger("event_logger")
@@ -28,16 +28,16 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
     def get_queryset(self):
         # Restrict to VAs this user can access and prefetch related for performance
         queryset = self.request.user.verbal_autopsies().prefetch_related("location", "causes", "coding_issues").order_by("id")
-        self.filterset = VAFilter(data=self.request.GET or None, queryset=queryset)
-        if self.request.user.is_fieldworker:
-            del self.filterset.form.fields['interviewer']
+        # TODO: For now, we are not displaying the filters for the Field Worker on the VA index page,
+        # since many do not apply to them. This prevents data passed through the params from being
+        # passed to the VAFilter
+        # Also hide filter if the user cannot view PII since the filterable fields contain PII.
+        if self.request.user.is_fieldworker() or not self.request.user.can_view_pii:
+            self.filterset = VAFilter(data=None, queryset=queryset)
 
-        # Don't allow search based on fields the user can't see anyway
-        if not self.request.user.can_view_pii:
-            del self.filterset.form.fields['deceased']
-            del self.filterset.form.fields['start_date']
-            del self.filterset.form.fields['end_date']
-
+        # do the filtering thing
+        else:
+            self.filterset = VAFilter(data=self.request.GET or None, queryset=queryset)
         query_dict = self.request.GET.dict()
         query_keys = [k for k in query_dict if k != 'csrfmiddlewaretoken']
         if len(query_keys) > 0:
@@ -50,27 +50,17 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
         context = super().get_context_data(**kwargs)
 
         context["filterset"] = self.filterset
-        if not self.request.user.is_fieldworker():
-            context['object_list'] = [{
-                "id": va.id,
-                "deceased": f"{va.Id10017} {va.Id10018}",
-                "interviewer": va.Id10010,
-                "date":  va.Id10023 if (va.Id10023 != 'dk') else "Unknown", #django stores the date in yyyy-mm-dd
-                "facility": va.location.name if va.location else "",
-                "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
-                "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
-                "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
-            } for va in context['object_list']]
-        else:
-            context['object_list'] = [{
-                "id": va.id,
-                "deceased": f"{va.Id10017} {va.Id10018}",
-                "date":  va.Id10023 if (va.Id10023 != 'dk') else "Unknown", #django stores the date in yyyy-mm-dd
-                "facility": va.location.name if va.location else "",
-                "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
-                "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
-                "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
-            } for va in context['object_list']]
+        #parse_date(va.Id10023)
+        context['object_list'] = [{
+            "id": va.id,
+            "deceased": f"{va.Id10017} {va.Id10018}", 
+            "interviewer": va.Id10010,
+            "date":  parse_date(va.submissiondate) if (va.submissiondate != 'dk') else "Unknown", #django stores the date in yyyy-mm-dd
+            "facility": va.location.name if va.location else "",
+            "cause": va.causes.all()[0].cause if len(va.causes.all()) > 0 else "",
+            "warnings": len([issue for issue in va.coding_issues.all() if issue.severity == 'warning']),
+            "errors": len([issue for issue in va.coding_issues.all() if issue.severity == 'error'])
+        } for va in context['object_list']]
 
         context.update(get_va_summary_stats(self.filterset.qs))
 


### PR DESCRIPTION
This PR is a stripped-down version of original date-fix PR that only includes changes necessary for date changes.
This PR:
  replaces Date of Death with Submission Date on the home page and data management tabs
  Adds detail to table header explaining which dates are being used
  adds logic to render home page properly when no VAs are in system
  adds ingest logic to parse `submissiondate`
  closes #151 