### PR TITLE
optimized queries to calculate summary stats

### DIFF
--- a/va_explorer/va_analytics/utils/rendering.py
+++ b/va_explorer/va_analytics/utils/rendering.py
@@ -7,10 +7,10 @@ def render_update_header(va_stats):
         assert "last_update" in va_stats and "last_submission" in va_stats
         if va_stats["last_update"] or va_stats["last_submission"]:
             if va_stats["last_update"]:
-                update_desc = html.P(children=[html.I("Last Data Update: "), html.I(va_stats["last_update"])], style={"margin-left": "20px"})
+                update_desc = html.P(children=[html.B("Last Data Update: "), va_stats["last_update"]], style={"margin-left": "20px"})
                 header.children.append(update_desc)
             if va_stats["last_submission"]:
-                submission_desc = html.P(children=[html.I("Last VA Submission: "), html.I(va_stats["last_submission"])], style={"margin-left": "10px"})
+                submission_desc = html.P(children=[html.B("Last VA Submission: "), html.Span(va_stats["last_submission"])], style={"margin-left": "10px"})
                 header.children.append(submission_desc)
             if va_stats.get("ineligible_vas", None):
                 ineligible_tooltip = "VAs excluded from dashboard due to missing location, date of death (Id10023) or both."

--- a/va_explorer/va_data_management/utils/loading.py
+++ b/va_explorer/va_data_management/utils/loading.py
@@ -1,10 +1,12 @@
 import pandas as pd
-from pandas import to_datetime as to_dt
 import numpy as np
-from simple_history.utils import bulk_create_with_history
+import time
 import logging
+
+from pandas import to_datetime as to_dt
+from simple_history.utils import bulk_create_with_history
 from django.contrib.auth import get_user_model
-from django.db.models import Q
+from django.db.models import Max, Count, Q
 
 from va_explorer.va_data_management.models import VerbalAutopsy, VaUsername
 from va_explorer.va_data_management.utils.validate import validate_vas_for_dashboard
@@ -15,8 +17,6 @@ from va_explorer.users.utils.field_worker_linking import assign_va_usernames, no
 
 
 User = get_user_model()
-import time
-
 
 def load_records_from_dataframe(record_df, random_locations=False, debug=True):
     ti = t0 = time.time()
@@ -185,27 +185,24 @@ def deduplicate_columns(record_df, drop_duplicates=True):
         record_df = record_df.drop(columns=other_cols)
     return record_df
 
+# calculate key summary statistics about a VA queryset
 def get_va_summary_stats(vas):
-    # track last data update and submission date
-    stats = {'last_submission': None, 'last_update': None, 'total_vas': vas.count()}
-    if stats['total_vas'] > 0:
-        # Track last time VAs were updated. Again, using last import date so may need to change.
-        last_update = max(vas.values_list('created', flat=True))
-        if not pd.isnull(last_update):
-            stats['last_update'] =  last_update.strftime('%d %b, %Y')
-        # Record latest submission date (from ODK). Column may/may not be available depending on source
-        raw_submissions = to_dt(get_submissiondates(vas))
+    # filter down to only relevant fields
+    vas = vas.only("created", "id", "location", "Id10023")
+    stats = vas.aggregate(last_update=Max("created"),\
+                        last_submission=Max("submissiondate"),\
+                        total_vas=Count("id"))
 
-        # track number of ineligible VAs for dashboard
-        stats['ineligible_vas'] = vas.filter(Q(Id10023__in=['DK','dk']) | Q(Id10023__isnull=True)|\
-         Q(location__isnull=True)).count()
-        if raw_submissions.count() > 0:
-            try:
-                last_submission = to_dt(raw_submissions).max()
-            except:
-                last_submission = to_dt(pd.Series(to_dt(raw_submissions, utc=True)).dt.date).max()
-            if not pd.isnull(last_submission):
-                stats['last_submission'] = last_submission.strftime('%d %b, %Y')
+    stats['ineligible_vas'] = vas.filter(Q(Id10023__in=['DK','dk']) | Q(Id10023__isnull=True)|\
+     Q(location__isnull=True)).count()
+
+    # clean up dates if non-null
+    if stats["last_update"] and type(stats["last_update"]) is not str:
+        stats["last_update"] = stats["last_update"].strftime('%Y-%m-%d')
+
+    if stats["last_submission"] and type(stats["last_update"]) is not str:
+        stats["last_submission"] = stats["last_submission"].strftime('%Y-%m-%d')
+
     return stats
 
 

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -18,6 +18,8 @@ from va_explorer.va_logs.logging_utils import write_va_log
 from va_explorer.va_data_management.utils.validate import validate_vas_for_dashboard
 from va_explorer.va_data_management.utils.date_parsing import parse_date, get_submissiondate
 
+import time
+
 
 LOGGER = logging.getLogger("event_logger")
 
@@ -51,6 +53,8 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
         context = super().get_context_data(**kwargs)
 
         context["filterset"] = self.filterset
+
+        ti = time.time()
         context['object_list'] = [{
             "id": va.id,
             "deceased": f"{va.Id10017} {va.Id10018}",
@@ -64,6 +68,7 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
         } for va in context['object_list']]
 
         context.update(get_va_summary_stats(self.filterset.qs))
+        print(f"total time to format display VAs: {time.time() - ti} secs")
 
         return context
 


### PR DESCRIPTION
This PR addresses a bottleneck in the summary stats function preventing dashboard and data management tabs from loading at scale. Query optimizations led to drastic improvement in load times. To test, 
1) load VA db with 10k VAs
2) (optional) run coding algorithm
3) checkout main and try loading data management tab. Confirm it takes a few minutes to load. 
4) switch to this branch and render data management tab again. Confirm it new loads in a matter of seconds. 