### PR TITLE
Update apache guidance to include gzip

### DIFF
--- a/compose/django/start
+++ b/compose/django/start
@@ -9,8 +9,6 @@ export DJANGO_SETTINGS_MODULE=config.settings.production
 echo "Initializing log directory..."
 python /app/manage.py initialize_log_directory
 
-chown django:django /app/va_explorer/va_logs/logfiles
-
 echo "Running database migrations..."
 python /app/manage.py migrate
 


### PR DESCRIPTION
I did some testing with various app states + apache states to get a concrete idea how gzip might affect serving VAs. I've included my report below.

This MR adds documentation for VA Explorer admins to make setup of an apache reverse proxy server easier.
Tangentially, this MR makes a small change to the django docker container to fix a bug that prevented benchmarking.

# Benchmarking Report
## Common
### Benchmarking Tool(s): 
- Apache Benchmark `ab`

### Test Conditions:
- Performed locally on the same hostname box
- Performed on va_explorer commit `2ba133858aa6a679e170ed459b23bcae60065aa7` (Nov 3, 2021)
- Bonus Performed on va_explorer commit `9e815515614454d2bd7978046fa799b82fcd83b1` (Nov 24, 2021)
- 10,000 total requests
- 100 sent concurrently
- Cookie: csrftoken=<admin user token>; sessionid=<manual login copied over>
- Url: https://va-explorer.mitre.org/va_analytics/dashboard/
- Total Time Timeout: 300 seconds (5 minutes)

### Test Variables:
- EMPTY state: Defined as 1 admin, no VAs, users, locations, or other data
- POPULATED state: Defined as 10k Coded VAs, 1 admin, 10 linked field workers, locations loaded
- gzip compression ON: Apache deflate module enabled
- gzip compression OFF: Apache deflate module disabled (default)

### Command:
```
ab -t 300 -n 10000 -c 100 -C "csrftoken=[redacted]; sessionid=[redacted]" https://va-explorer.mitre.org/va_analytics/dashboard/
```

## Interpreting The Results
_Adapted From: https://linuxconfig.org/how-to-benchmark-webserver-with-apache-bench_

**Time taken for tests:** reports how long the ab command took to complete its test.

**Complete requests:** reports how many of the requests were sent and returned successfully.

**Failed requests:** reports how many of the requests were unable to complete. If this row does report some failed requests, it could indicate that the web server was overwhelmed and unable to respond to all requests in time.

**Total transferred and HTML transferred:** rows report how much data, in bytes, was sent to the web server.

**Requests per second:** is the average of how many requests the web server was able to handle in a second. It’s useful in determining how your web server will perform when many users are logging onto it at the same time.

**Time per request:** is how much time, on average, it took to process a request in milliseconds. The second time per request value is simply multiplied by the concurrency value.

**Transfer rate:** is how fast it was able to transfer the data, which shouldn’t pose any kind of a bottleneck on a local network. If testing over the internet, the routing and bandwidth limitations could affect this value long before Apache itself.

_**Note:** Because these tests were performed locally on the hostname box (and not a Zambia server for example), this may not be a very useful metric in this case_

**Connection Times (ms) section:** lists response times for different stages of the HTTP requests.

- **Connect:** indicates how much time it took ab to establish a connection with the web server.
- **Processing:** is the amount of time that Apache spent processing the requests. Since ab can’t actually measure this, it just records the amount of time a connection is open after being initiated.
- **Waiting:** is how long ab has to wait between sending a request and receiving a response from the web server.
- **Total:** indicates the total time elapsed from initiating a connection to the server, receiving a response, and finally closing the connection.

**Average response time sorted into percentiles:** Shows 50% of the HTTP requests were handled and closed in only x ms or less. 66% were handled in y ms or less, and so on. The top percentages tend to indicate the 2 longest requests and may be used to indicate outliers. Another way of reading this may be "90% of our HTTP requests were handled in less than n seconds."

### Report Headers
```
Server Software:        gunicorn/20.0.4
Server Hostname:        va-explorer.mitre.org
Server Port:            443
SSL/TLS Protocol:       TLSv1.2,ECDHE-RSA-AES256-GCM-SHA384,2048,256
TLS Server Name:        va-explorer.mitre.org

Document Path:          /va_analytics/dashboard/
Document Length:        5824 bytes

Concurrency Level:      100
```

## Test 1: EMPTY state, gzip compression OFF
```
Time taken for tests:   116.941 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      61630000 bytes
HTML transferred:       58240000 bytes
Requests per second:    85.51 [#/sec] (mean)
Time per request:       1169.407 [ms] (mean)
Time per request:       11.694 [ms] (mean, across all concurrent requests)
Transfer rate:          514.67 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        2    7  29.8      3     418
Processing:    84 1154 101.7   1145    1799
Waiting:       78 1152 101.7   1142    1789
Total:         92 1161  93.0   1150    1802

Percentage of the requests served within a certain time (ms)
  50%   1150
  66%   1190
  75%   1210
  80%   1226
  90%   1271
  95%   1296
  98%   1329
  99%   1380
 100%   1802 (longest request)
```


## Test 2: EMPTY state, gzip compression ON
```
Time taken for tests:   119.964 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      61790000 bytes
HTML transferred:       58240000 bytes
Requests per second:    83.36 [#/sec] (mean)
Time per request:       1199.644 [ms] (mean)
Time per request:       11.996 [ms] (mean, across all concurrent requests)
Transfer rate:          503.00 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        2    7  35.9      3     476
Processing:   144 1187 107.2   1171    2135
Waiting:      143 1185 107.2   1169    2134
Total:        185 1195 101.5   1176    2137

Percentage of the requests served within a certain time (ms)
  50%   1176
  66%   1220
  75%   1246
  80%   1263
  90%   1303
  95%   1343
  98%   1476
  99%   1510
 100%   2137 (longest request)
 ```


 ## Test 3: POPULATED state, gzip compression OFF
```
Time taken for tests:   127.285 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      61620000 bytes
HTML transferred:       58230000 bytes
Requests per second:    78.56 [#/sec] (mean)
Time per request:       1272.848 [ms] (mean)
Time per request:       12.728 [ms] (mean, across all concurrent requests)
Transfer rate:          472.76 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        2    9  43.8      3     590
Processing:    86 1258 100.5   1252    1979
Waiting:       81 1256 100.4   1249    1979
Total:        128 1267  93.6   1257    1982

Percentage of the requests served within a certain time (ms)
  50%   1257
  66%   1285
  75%   1307
  80%   1321
  90%   1368
  95%   1414
  98%   1468
  99%   1540
 100%   1982 (longest request)
```

### Chrome DevTools Network Tab Stats:
- 54 Requests
- 5.6 MB transferred
- 10.5 MB resources
- Finish: 13.79 seconds
- DOMContentLoaded 1.74 seconds


## Test 3: POPULATED state, gzip compression ON
```
Time taken for tests:   127.732 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      61780000 bytes
HTML transferred:       58230000 bytes
Requests per second:    78.29 [#/sec] (mean)
Time per request:       1277.319 [ms] (mean)
Time per request:       12.773 [ms] (mean, across all concurrent requests)
Transfer rate:          472.33 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        2    9  46.0      3     663
Processing:    34 1262 129.6   1255    2036
Waiting:       34 1260 129.5   1252    2028
Total:         53 1271 115.5   1259    2041

Percentage of the requests served within a certain time (ms)
  50%   1259
  66%   1298
  75%   1326
  80%   1346
  90%   1404
  95%   1463
  98%   1546
  99%   1564
 100%   2041 (longest request)
```

### Chrome DevTools Network Tab Stats:
- 54 Requests
- 2.3 MB transferred
- 10.5 MB resources
- Finish: 12.03 seconds
- DOMContentLoaded 1.87 seconds

## BONUS TEST: POPULATED state, gzip compression ON, code changed
Note: In this test a database query within the dashboard has been optimized
```
Time taken for tests:   123.422 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      61780000 bytes
HTML transferred:       58230000 bytes
Requests per second:    81.02 [#/sec] (mean)
Time per request:       1234.224 [ms] (mean)
Time per request:       12.342 [ms] (mean, across all concurrent requests)
Transfer rate:          488.83 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        2    8  38.3      3     561
Processing:    85 1221 104.5   1211    1976
Waiting:       85 1219 104.5   1209    1976
Total:        161 1229  94.7   1217    1979

Percentage of the requests served within a certain time (ms)
  50%   1217
  66%   1252
  75%   1271
  80%   1285
  90%   1333
  95%   1383
  98%   1472
  99%   1513
 100%   1979 (longest request)
```

### Chrome DevTools Network Tab Stats:
- 54 Requests
- 2.3 MB transferred
- 10.5 MB resources
- Finish: 8.87 seconds
- DOMContentLoaded 1.87 seconds


## Conclusions:
gzip seems to make minimal difference as far as the apache layer is concerned,
as evidenced by the benchmarking tests which report approximately equal results.

Further investigation reveals the benchmark test is only concerned with the
initial page load and not the data that has to be loaded into the dashboard
afterwards. To get an idea of that, for POPULATED state, the Chrome DevTools
Network tab was used to get a rough idea of total difference after initial page
load.

gzip seems to also make minimal difference here regarding speed. However,
the amount of data transferred was cut by roughly 59%. For this reason, the extra
configuration for gzip seems worth it.

The bonus test examining a code change suggests that speed improvements may be
found easier through other techniques such as query optimization, caching, or
otherwise - since the observed finish in Chrome DevTools was reduced by ~3 seconds.