### PR TITLE
added conditional statement for scipy install

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,7 +34,8 @@ channels==2.4.0
 daphne==2.5.0
 
 # Plotly
-scipy==1.5.2
+scipy==1.5.2; python_version == '3.7'
+scipy==1.7.3; python_version > '3.7'
 
 # Dash
 dash==1.14.0


### PR DESCRIPTION
This small change adds functionality to download different scipy versions depending on the Python version a user has installed.

It is important because Python 3.9 does not support scipy 1.5.2 as we originally used. So we have to use scipy 1.7.3 for Python 3.9 users. Similarily, Python 3.7 does not support Scipy 1.7.3, so we need to keep using 1.5.2 for Python 3.7 users.

if python version == 3.7: use scipy 1.5.2
if python version > 3.7: use scipy 1.7.3

can be tested locally by creating a fresh git pull, then running `pip install -r requirements/base.txt` using different python versions.