### PR TITLE
Changed scipy to 1.5.4 

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,7 +34,7 @@ channels==2.4.0
 daphne==2.5.0
 
 # Plotly
-scipy==1.5.2
+scipy==1.5.4
 
 # Dash
 dash==1.14.0


### PR DESCRIPTION
Changed scipy to 1.5.4 after finding 1.5.2 to not be compatible with some py versions. 

Can be tested with changing python versions and trying to install scipy 1.5.4 on each, and then making sure the app is functional. 
Thank you to @deastman for finding this fix.
Tested on Python 3.7 and 3.9 by @deastman and I tested on 3.8