### PR TITLE
Add docker-integrated cronjobs for ODK Import via ofelia 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,5 +332,6 @@ va_explorer/media/
 .env
 .envs/*
 !.envs/.local/
+*.pem
 
 pgdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,14 @@ volumes:
   production_postgres_data_backups: {}
   
 services:
+  ofelia:
+    image: mcuadros/ofelia:latest
+    depends_on:
+      - django
+    command: daemon --docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
   pycrossva:
     image: va_explorer/pycrossva
     build: https://github.com/VA-Explorer/pyCrossVA.git#microservice-experiment
@@ -43,9 +51,18 @@ services:
       DJANGO_DEFAULT_FROM_EMAIL: ${DJANGO_DEFAULT_FROM_EMAIL:-VA Explorer <noreply@vaexplorer.org>} 
       PYCROSS_HOST: ${PYCROSS_HOST:-http://pycrossva:80}
       INTERVA_HOST: ${INTERVA_HOST:-http://interva5:5002}
+      ODK_HOST: ${ODK_HOST:-http://localhost:81}
+      ODK_SSL_VERIFY: ${ODK_SSL_VERIFY}
+      ODK_EMAIL: ${ODK_EMAIL}
+      ODK_PASSWORD: ${ODK_PASSWORD}
     volumes:
       - ./va_explorer_logs:/app/va_explorer/va_logs/logfiles
     command: /start
+    labels:
+      ofelia.enabled: "true"
+      ofelia.job-exec.odk-import.schedule: "0 0 3 * * *"  # Every night at 3am
+      ofelia.job-exec.odk-import.command: "./manage.py import_from_odk --project-id=${ODK_PROJECT_ID} --form-id=${ODK_FORM_ID}"
+
 
   celeryworker:
     <<: *django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ django-allauth==0.44.0
 django-celery-beat==2.0.0
 django-crispy-forms==1.9.1
 django-debug-toolbar==3.1.1
-django-environ==0.4.5
+django-environ==0.8.1
 django-extensions==3.0.9
 django-redis==4.12.1
 django-simple-history==2.12.0
@@ -53,11 +53,11 @@ dpd-static-support==0.0.5
 pytest==6.2.1
 pytest-django==4.1.0
 factory-boy==2.12.0
-selenium==3.141.0
+selenium==4.1.0
 requests-mock==1.8.0
 
 # Database
 psycopg2==2.8.5 --no-binary psycopg2
 
-#openva pipeline
+# openva pipeline
 git+https://github.com/VA-Explorer/openva_pipeline.git@master

--- a/va_explorer/users/tests/test_user_create_browser.py
+++ b/va_explorer/users/tests/test_user_create_browser.py
@@ -3,6 +3,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.urls import reverse
 
 from selenium.webdriver.support.select import Select
+from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver import FirefoxOptions
 
@@ -22,11 +23,11 @@ def login_active_user(self):
     )
 
     self.selenium.get('%s%s' % (self.live_server_url, '/accounts/login/'))
-    username_input = self.selenium.find_element_by_name("login")
+    username_input = self.selenium.find_element(By.NAME, "login")
     username_input.send_keys(active_user.email)
-    password_input = self.selenium.find_element_by_name("password")
+    password_input = self.selenium.find_element(By.NAME, "password")
     password_input.send_keys(password)
-    self.selenium.find_element_by_xpath('//button[text()="Sign In"]').click()
+    self.selenium.find_element(By.XPATH, '//button[text()="Sign In"]').click()
 
 # TODO: Extract some of this out into a pytest fixture that can be shared across tests
 class BrowserTests(StaticLiveServerTestCase):
@@ -63,15 +64,15 @@ class BrowserTests(StaticLiveServerTestCase):
 
         assert 'Create a New User' in self.selenium.title
 
-        select = Select(self.selenium.find_element_by_id('id_group'))
+        select = Select(self.selenium.find_element(By.ID, 'id_group'))
 
-        facility_restrictions_dropdown = self.selenium.find_element_by_name('facility_restrictions')
-        location_restrictions_dropdown = self.selenium.find_element_by_name('location_restrictions')
+        facility_restrictions_dropdown = self.selenium.find_element(By.NAME, 'facility_restrictions')
+        location_restrictions_dropdown = self.selenium.find_element(By.NAME, 'location_restrictions')
 
-        national_access_radio = self.selenium.find_element_by_xpath('//input[@value="national"]')
-        location_specific_radio = self.selenium.find_element_by_xpath('//input[@value="location-specific"]')
+        national_access_radio = self.selenium.find_element(By.XPATH, '//input[@value="national"]')
+        location_specific_radio = self.selenium.find_element(By.XPATH, '//input[@value="location-specific"]')
 
-        va_username_input = self.selenium.find_element_by_name('va_username')
+        va_username_input = self.selenium.find_element(By.NAME, 'va_username')
 
         # Before a role is chosen
         assert not facility_restrictions_dropdown.is_displayed()

--- a/va_explorer/va_data_management/utils/odk.py
+++ b/va_explorer/va_data_management/utils/odk.py
@@ -6,8 +6,12 @@ import pandas as pd
 import requests
 
 ODK_HOST = os.environ.get('ODK_HOST', 'http://127.0.0.1:5002')
-# Don't verify localhost (self-signed cert). Support multiple boolean representations in .env
-SSL_VERIFY = os.environ.get('ODK_SSL_VERIFY', not ODK_HOST.startswith('https://localhost')).lower() in ('true', '1', 't')
+if ODK_HOST.startswith('https://localhost'):
+    # Don't verify localhost (self-signed cert or test).
+    SSL_VERIFY = False
+else:
+    # Support multiple user-provided boolean representations from .env
+    SSL_VERIFY = os.environ.get('ODK_SSL_VERIFY', 'TRUE').lower() in ('true', '1', 't')
 
 
 def flatten_dict(item):

--- a/va_explorer/va_data_management/utils/odk.py
+++ b/va_explorer/va_data_management/utils/odk.py
@@ -6,8 +6,8 @@ import pandas as pd
 import requests
 
 ODK_HOST = os.environ.get('ODK_HOST', 'http://127.0.0.1:5002')
-# Don't verify localhost (self-signed cert)
-SSL_VERIFY = os.environ.get('ODK_SSL_VERIFY', not ODK_HOST.startswith('https://localhost'))
+# Don't verify localhost (self-signed cert). Support multiple boolean representations in .env
+SSL_VERIFY = os.environ.get('ODK_SSL_VERIFY', not ODK_HOST.startswith('https://localhost')).lower() in ('true', '1', 't')
 
 
 def flatten_dict(item):


### PR DESCRIPTION
This issue introduces cron style automation to VA Explorer, starting with ODK imports so that admins do not have to manually run this management command.

Specifically it:
- Updates docker-compose to add [ofelia](https://github.com/mcuadros/ofelia) service specifically for docker environments that avoids the potential problems discussed in alternative consideration #106 lists
- Adds an initial cronjob to our django container to run the `import_from_odk` management command every night at 3am
- Updates django service to ensure all ODK specific variables are injected into the container from `.env` at build time
- Fixes an issue in `odk.py` where True/False in `.env` would be parsed as a string and cause requests.get to throw errors.

To verify this was working as expected I:
- ensured that my `.env` was populated with `ODK_HOST`, `ODK_SSL_VERIFY`, `ODK_PROJECT_ID`, `ODK_FORM_ID`, `ODK_EMAIL`, and `ODK_PASSWORD` with email and password being auth info for a local instance of the odk-central application
- temporarily changed to this line in docker-compose
```
ofelia.job-exec.odk-import.schedule: "@every 1m"
```
- re-ran `docker-compose up -d --build`
- observed the job successfully ("failed: false, ..., error: none") running every minute via `docker-compose logs -f django ofelia`

**Note:** currently it seems that having these variables defined in `.env` is not compatible with running pytest as it relies on default values. It may be worth opening an issue to address this, in the meantime I commented out my `.env` before running `pytest`

Closes #106 