### PR TITLE
Support 'indeterminate' CoD designations

### DIFF
--- a/va_explorer/templates/home/index.html
+++ b/va_explorer/templates/home/index.html
@@ -80,6 +80,19 @@
       <strong>No coding issues found!</strong>
       <p>Head over to the <a href="/va_analytics/dashboard">dashboard</a> to analyze VAs</p>
     {% endif %}
+  <div>
 </div>
+<div class="row mt-4">
+    <div class="col">
+      <h2 class="mb-4">VAs With Indeterminate Cause of Death</h2>
+      {% if indeterminate_cod_list %}
+        {% include 'partials/_va_table.html' with va_list=indeterminate_cod_list %}
+        {% if additional_indeterminate_cods > 0 %}<p>There are <a href="/va_data_management/?cause=Indeterminate" id="additional_issues">{{ additional_indeterminate_cods }} additional VAs with Indeterminate Cause of Death</a> not listed here</p>{% endif %}
+      {% else %}
+        <strong>No VAs with Indeterminate Cause of Death found!</strong>
+        <p>Head over to the <a href="/va_analytics/dashboard">dashboard</a> to analyze VAs</p>
+      {% endif %} 
+  </div>
+<div>
 
 {% endblock %}

--- a/va_explorer/va_analytics/dash_apps/va_dashboard.py
+++ b/va_explorer/va_analytics/dash_apps/va_dashboard.py
@@ -859,6 +859,9 @@ app.clientside_callback(
                 const sorted = new Map(Object.entries(obj).sort((a, b) => b[1] - a[1]));
                 
                 metrics = Array.from(sorted.keys()).slice(0,N);
+                
+                // Manually adds "Indeterminate" to COD dropdown if it doesn't exist
+                // TODO: Once additional algorithms are added, will need to add logic that checks if "Indeterminate" is a valid COD
                 if (!metrics.includes("Indeterminate")) {
                     metrics.push("Indeterminate");
                 }

--- a/va_explorer/va_analytics/dash_apps/va_dashboard.py
+++ b/va_explorer/va_analytics/dash_apps/va_dashboard.py
@@ -858,8 +858,11 @@ app.clientside_callback(
                 
                 const sorted = new Map(Object.entries(obj).sort((a, b) => b[1] - a[1]));
                 
-                metrics = Array.from( sorted.keys() ).slice(0,N);
-                metrics.unshift("all")
+                metrics = Array.from(sorted.keys()).slice(0,N);
+                if (!metrics.includes("Indeterminate")) {
+                    metrics.push("Indeterminate");
+                }
+                metrics.unshift("all");
             }
         }
 

--- a/va_explorer/va_analytics/utils/plotting.py
+++ b/va_explorer/va_analytics/utils/plotting.py
@@ -92,6 +92,7 @@ def load_lookup_dicts():
         "Other and unspecified infect dis": "Other infectious disease",
         "Other and unspecified maternal CoD": "Other maternal CoD",
         "Pregnancy-induced hypertension": "Hypertension from Pregnancy",
+        "Indeterminate": "Indeterminate",
 
         # internal cod group labels to plot titles
         "All CODs": "All Causes",

--- a/va_explorer/va_data_management/management/commands/run_coding_algorithms.py
+++ b/va_explorer/va_data_management/management/commands/run_coding_algorithms.py
@@ -24,10 +24,10 @@ class Command(BaseCommand):
                 self.clear_and_save_old_cods(options['cod_fname'])
 
             print('coding all eligible VAs... ')
-            results = run_coding_algorithms()
-            num_coded = len(results['causes'])
-            num_total = len(results['verbal_autopsies'])
-            num_issues = len(results['issues'])
+            verbal_autopsies, causes, issues = run_coding_algorithms()
+            num_coded = len(causes)
+            num_total = len(verbal_autopsies)
+            num_issues = len(issues)
             self.stdout.write(f'DONE. Total time: {time.time() - ti} secs')
             self.stdout.write(f'Coded {num_coded} verbal autopsies (out of {num_total}) [{num_issues} issues]')
         else:


### PR DESCRIPTION
# Description
Ticket: [Support 'indeterminate' CoD designations](https://github.com/VA-Explorer/va_explorer/issues/153)

Leverages the updates made to the InterVA5 microservice to assign Indeterminate CoD. Shows Indeterminate CoD on the homepage as well as within the Dashboard. 

Per demo feedback, reduces the number of entries in the VAs With Coding Issues and VAs With Indeterminate Cause of Death tables to 5. 

## Demo/Screenshots
**Adds first five Indeterminate CoD to table within the home page, if any exist.**
<img width="1140" alt="Screen Shot 2022-03-07 at 9 42 43 AM" src="https://user-images.githubusercontent.com/2328582/157056125-ac6190d4-0d8c-42e1-b22f-a69c98ca674e.png">


**Adds link underneath Indeterminate CoD table that brings user to filtered Data Management page**
<img width="1140" alt="Screen Shot 2022-03-07 at 9 45 02 AM" src="https://user-images.githubusercontent.com/2328582/157056333-a2911461-7a5c-4803-be3c-8c7eea84b09b.png">


**Adds Indeterminate to dropdown on Dashboard**
<img width="1749" alt="Screen Shot 2022-03-07 at 9 46 04 AM" src="https://user-images.githubusercontent.com/2328582/157057347-59c933dc-7b8a-46a8-8734-b75ed352b6ce.png">

## Important Changes
`va_explorer/va_data_management/utils/coding.py`
- Adds `api: 'True` to InterVA5 ALGORITHM_SETTINGS, per Matt's update to the InterVA5 microservice
- Adds logic to assign cause to "Indeterminate" if 'CAUSE1' == '' and 'INDET' == 100 and 'LIK1' == ''

`va_explorer/home/views.py`
- Adds `indeterminate_cod_list` to context

`va_explorer/va_analytics/dash_apps/va_dashboard.py`
- Adds "Indeterminate" to dashboard Cause dropdown

## Testing Recommendations
- Import mock_data_2.csv from [Verbal Autopsy Resources](https://gitlab.mitre.org/verbal-autopsy/va_explorer_resources) by `./manage.py load_va_csv mock_data_2.csv`
- Run the coding algorithm: `python manage.py run_coding_algorithms --overwrite=True`
- Visit the homepage
- Confirm there are 5 VAs with Indeterminate COD and 10 additional VAs
- Click on link, 10 additional VAs with Indeterminate Cause of Death
- Confirm that table is filtered by Indeterminate and that there are 15 VAs
- Visit the Dashboard
- Confirm that Indeterminate is present in the Cause of Death Dropdown
- Filter Dashboard by Cause of Death, "Indeterminate"