### PR TITLE
VA 211 Bugfix: Exception thrown within Customize VA Export when export is empty

### DIFF
--- a/va_explorer/va_export/tests/test_views.py
+++ b/va_explorer/va_export/tests/test_views.py
@@ -37,6 +37,7 @@ def build_test_db():
     district2 = province.add_child(name='District2', location_type='district')
     facility_b = district2.add_child(name='Facility2', location_type='facility')
     facility_c = district2.add_child(name='Facility2', location_type='facility')
+    district2.add_child(name='No VA Facility', location_type='facility')
 
     # create VAs
     va1 = VerbalAutopsyFactory.create(location=facility_a, Id10023="2019-01-01")
@@ -97,7 +98,33 @@ class TestAPIView:
         download_ct = json_data['count']
         assert download_ct == db_va_ct
 
-    def test_location_filtering(self, rf:RequestFactory):
+    def test_download_csv_with_no_matching_vas(self, rf: RequestFactory):
+        build_test_db()
+        # only download data from "No VA Facility", which will have no matching VAs
+        no_va_facility = Location.objects.get(name="No VA Facility")
+
+        request = rf.get(f"/va_export/verbalautopsy/?format=csv&locations={no_va_facility.pk}")
+        request.user = User.objects.get(name='admin')
+        response = va_api_view(request)
+
+        assert response.status_code == 200
+        # Assert content consists only of line break
+        assert response.content.decode("utf-8") == "\n"
+
+    def test_download_json_with_no_matching_vas(self, rf: RequestFactory):
+        build_test_db()
+        # only download data from "No VA Facility", which will have no matching VAs
+        no_va_facility = Location.objects.get(name="No VA Facility")
+
+        request = rf.get(f"/va_export/verbalautopsy/?format=json&locations={no_va_facility.pk}")
+        request.user = User.objects.get(name='admin')
+        response = va_api_view(request)
+
+        assert response.status_code == 200
+        # Assert content consists of the correct object
+        assert response.content.decode("utf-8") == '{"count": 0, "records": "[]"}'
+
+    def test_location_filtering(self, rf: RequestFactory):
         build_test_db()
         # only download data from location a
         loc_a = Location.objects.get(name="Facility1")

--- a/va_explorer/va_export/views.py
+++ b/va_explorer/va_export/views.py
@@ -107,6 +107,8 @@ class VaApi(CustomAuthMixin, View):
 				matching_vas = matching_vas.filter(cause__in=match_list)
 
 		#=========DATA CLEANING (if any matching VAs)========#
+		va_df = pd.DataFrame()
+		
 		if matching_vas.count() > 0:
 			# Build a location ancestors lookup and add location information at all levels to all vas
 			location_ancestors = {


### PR DESCRIPTION
# Description
Ticket: [Exception thrown within Customize VA Export when export is empty](https://github.com/VA-Explorer/va_explorer/issues/211)

When the options chosen in the VA Export page dropdowns result in no matching Verbal Autopsies, an exception is thrown as per the partial stacktrace below:

```
  File "/Users/deastman/va_explorer/venv/lib/python3.9/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/deastman/va_explorer/va_explorer/utils/mixins.py", line 17, in dispatch
    return super(CustomAuthMixin, self).dispatch(request, *args, **kwargs)
  File "/Users/deastman/va_explorer/venv/lib/python3.9/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/deastman/va_explorer/va_explorer/va_export/views.py", line 149, in get
    response.write(va_df.to_csv(index=False))
UnboundLocalError: local variable 'va_df' referenced before assignment
```

## How to Replicate
1. Go to 'http://0.0.0.0:8000/va_export/'
2. Choose "Download Data"
3. Set the parameters such that there are no matching Verbal Autopsies in your local environment
4. Choose Data Format, "csv" or "json"
5. See error, `UnboundLocalError: local variable 'va_df' referenced before assignment`

## Solution
`va_df` is only defined within the if block `if matching_vas.count() > 0:` When there are no matching VAs, `va_df` is undefined because this block is never entered. This PR moves `va_df` outside of this if block.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`va_explorer/va_export/tests/test_views.py`
- Adds tests to explicitly test for the cases in which there is an empty csv and json due to no matching filters

`va_explorer/va_export/views.py`
- Moves `va_df` outside of this if block

## Testing Recommendations
1. Go to 'http://0.0.0.0:8000/va_export/'
2. Choose "Download Data"
3. Set the parameters such that there are no matching Verbal Autopsies in your local environment
4. Choose Data Format, "csv" or "json"
5. Confirm that download works and you get an empty csv file or json file with `{"count": 0, "records": "[]"}`

