### PR TITLE
Add docker-compose.prod.yml + instructions for shared networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The server will be running at http://0.0.0.0:8000/
 
 Django can run locally inside Docker. This will also set up postgres and redis and automatically configure `DATABASE_URL` and `CELERY_BROKER_URL` to use the docker images of postgres and redis.
 
-Additionally, create an sharable network VA Explorer and other docker-compose apps such as ODK Central can join
+Additionally, create an sharable network that VA Explorer and other docker-compose apps such as ODK Central can join
 
     `docker network create va-net`
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Once the prerequisites are available, VA Explorer can be installed and demonstra
     *  `DATABASE_URL=psql://<YOUR POSTGRESUSER>:<POSTGRESUSER PASSWORD>@localhost/va_explorer`
     *  `CELERY_BROKER_URL=redis://localhost:6379/0`
 
-
 * Run the database migrations
     * `./manage.py makemigrations`
     * `./manage.py migrate`
@@ -170,11 +169,26 @@ The server will be running at http://0.0.0.0:8000/
 
 Django can run locally inside Docker. This will also set up postgres and redis and automatically configure `DATABASE_URL` and `CELERY_BROKER_URL` to use the docker images of postgres and redis.
 
+Additionally, create an sharable network VA Explorer and other docker-compose apps such as ODK Central can join
+
+    `docker network create va-net`
+
 ```
-docker-compose -f docker-compose.yml -f docker-compose.local.yml up django vapostgres
+docker-compose -f docker-compose.prod.yml -f docker-compose.local.yml up django vapostgres
 ```
 
 The server will be running at http://0.0.0.0:5000/
+
+If you have other docker-compose apps such as ODK Central that need to
+communicate with VA Explorer, they will also need to join the shared network
+created above. Add the following to said app's `docker-compose.yml` to support
+this:
+```yml
+networks:
+  default:
+    external:
+      name: va-net
+```
 
 ### Building for Production
 

--- a/README.md
+++ b/README.md
@@ -167,28 +167,32 @@ The server will be running at http://0.0.0.0:8000/
 
 ## Building/Running in Docker
 
-Django can run locally inside Docker. This will also set up postgres and redis and automatically configure `DATABASE_URL` and `CELERY_BROKER_URL` to use the docker images of postgres and redis.
+Django can run locally inside Docker. Doing so will also set up postgres and redis and automatically configure `DATABASE_URL` and `CELERY_BROKER_URL` to use the docker images of postgres and redis.
 
-Additionally, create an sharable network that VA Explorer and other docker-compose apps such as ODK Central can join
 
-    `docker network create va-net`
+**Note**: If you have other docker-compose apps such as ODK Central that need to
+communicate with VA Explorer, you will need to create a sharable network that both can join before building. This can be done by first running
 
 ```
-docker-compose -f docker-compose.prod.yml -f docker-compose.local.yml up django vapostgres
+docker network create va-net
 ```
 
-The server will be running at http://0.0.0.0:5000/
-
-If you have other docker-compose apps such as ODK Central that need to
-communicate with VA Explorer, they will also need to join the shared network
-created above. Add the following to said app's `docker-compose.yml` to support
-this:
+then updating the other docker-compose apps' `docker-compose.yml` to enable network sharing:
 ```yml
 networks:
   default:
     external:
       name: va-net
 ```
+
+Then, you can build and deploy VA Explorer by running the following:
+```
+docker-compose -f docker-compose.prod.yml -f docker-compose.local.yml up django vapostgres
+```
+
+The server will be running at http://0.0.0.0:5000/
+
+
 
 ### Building for Production
 

--- a/README.md
+++ b/README.md
@@ -169,15 +169,13 @@ The server will be running at http://0.0.0.0:8000/
 
 Django can run locally inside Docker. Doing so will also set up postgres and redis and automatically configure `DATABASE_URL` and `CELERY_BROKER_URL` to use the docker images of postgres and redis.
 
-
-**Note**: If you have other docker-compose apps such as ODK Central that need to
-communicate with VA Explorer, you will need to create a sharable network that both can join before building. This can be done by first running
-
+First, create a sharable nework for VA Explorer: 
 ```
 docker network create va-net
 ```
 
-then updating the other docker-compose apps' `docker-compose.yml` to enable network sharing:
+Next, if you have other docker-compose apps such as ODK Central that need to
+communicate with VA Explorer, you will need to update each app's `docker-compose.yml` to enable network sharing:
 ```yml
 networks:
   default:
@@ -185,7 +183,7 @@ networks:
       name: va-net
 ```
 
-Then, you can build and deploy VA Explorer by running the following:
+Finally, build and deploy VA Explorer by running the following:
 ```
 docker-compose -f docker-compose.prod.yml -f docker-compose.local.yml up django vapostgres
 ```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,89 @@
+version: '3'
+
+volumes:
+  production_postgres_data: {}
+  production_postgres_data_backups: {}
+  
+services:
+  pycrossva:
+    image: va_explorer/pycrossva
+    build: https://github.com/VA-Explorer/pyCrossVA.git#microservice-experiment
+    ports:
+      - "5001:80"
+    
+  interva5:
+    image: va_explorer/interva5
+    build: https://github.com/VA-Explorer/InterVA5.git#microservice-experiment
+    ports:
+      - "5002:5002"
+
+  redis:
+    image: redis:5.0
+
+  django: &django
+    image: va_explorer/django
+    build:
+      context: .
+      dockerfile: ./compose/django/Dockerfile
+    ports:
+      - "5000:5000"
+    depends_on:
+      - redis
+    environment:
+      EMAIL_URL: ${EMAIL_URL:-smtp://localhost:25}
+      CELERY_BROKER_URL: ${CELERY_BROKER_URL:-redis://redis:6379/0}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      POSTGRES_HOST: ${POSTGRES_HOST:-vapostgres}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_DB: ${POSTGRES_DB:-va_explorer}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-Pimin73y!we}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-dcc02e52ccbb649b9febe9182abfa5e03c49be6c}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost}
+      DJANGO_DEFAULT_FROM_EMAIL: ${DJANGO_DEFAULT_FROM_EMAIL:-VA Explorer <noreply@vaexplorer.org>} 
+      PYCROSS_HOST: ${PYCROSS_HOST:-http://pycrossva:80}
+      INTERVA_HOST: ${INTERVA_HOST:-http://interva5:5002}
+    volumes:
+      - ./va_explorer_logs:/app/va_explorer/va_logs/logfiles
+    command: /start
+
+  celeryworker:
+    <<: *django
+    # Don't publish ports like django does.
+    ports: []
+    image: va_explorer/celeryworker
+    command: /start-celeryworker
+
+  celerybeat:
+    <<: *django
+    # Don't publish ports like django does.
+    ports: []
+    image: va_explorer/celerybeat
+    command: /start-celerybeat
+
+  flower:
+    <<: *django
+    # Don't publish ports like django does.
+    ports: []
+    image: va_explorer/flower
+    command: /start-celeryflower
+
+  vapostgres:
+    image: va_explorer/postgres
+    build:
+      context: .
+      dockerfile: ./compose/postgres/Dockerfile
+    environment:
+      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_DB: ${POSTGRES_DB:-va_explorer}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-Pimin73y!we}
+    volumes:
+      - production_postgres_data:/var/lib/postgresql/data
+      - production_postgres_data_backups:/backups
+
+networks:
+  default:
+    external:
+      name: va-net


### PR DESCRIPTION
Fixes issue where VA Explorer is unable to import from ODK Central apps deployed via docker-compose on the same host due to docker-compose creating segregated networks for each.

Adds method and instructions for creating and joining a shared docker network external to the compose default.