### PR TITLE
VA-Explorer-219: Tabs are not functioning correctly on the VA Data Management show page (Bugfix)

### DIFF
--- a/va_explorer/templates/va_data_management/show.html
+++ b/va_explorer/templates/va_data_management/show.html
@@ -93,9 +93,7 @@
         </table>
       </div>
     {% endif %}
-  </div>
-
-  {% if algo_warnings %}
+    {% if algo_warnings %}
       <div class="row mt-4">
         <table class="table table-hover table-sm">
           <thead>
@@ -112,7 +110,6 @@
       </div>
     {% endif %}
   </div>
-
 
   {% if diffs and not user.is_fieldworker  %}
     <div class="tab-pane fade" id="history" role="tabpanel" aria-labelledby="history-tab">


### PR DESCRIPTION
# Description
[VA-Explorer-219](https://github.com/VA-Explorer/va_explorer/issues/219)

The list of coding issues is present on all tabs within the VA Data Management show page. The coding issues should only appear under the "Coding Issues" tab. After clicking on the "Change History" tab, the change history is also present on all tabs within the VA Data Management show page.

This PR fixes this issue so that the content on the tabs remains separate. 

## (Bugfix) How to Replicate
Steps to reproduce the behavior:
1. View a Verbal Autopsy that has coding issues. 
2. Scroll to the bottom of the Record tab. Observe that the coding issues are present within this view, under the Verbal Autopsy.
3. Click on Change History tab. Observe that the coding issues are present within this view, above the Change history. Then go back to the Record tab and observe that the change history is present within this view. 

## (Bugfix) Solution
There was an erroneous `</div>` in the show html, which was removed. 

## Testing Recommendations
View a Verbal Autopsy that has coding issues as well as a change history. Confirm that each tab only displays the relevant data for the tab. 
