### PR TITLE
Hide Delete All button if no permission.

### DIFF
--- a/va_explorer/templates/va_data_cleanup/index.html
+++ b/va_explorer/templates/va_data_cleanup/index.html
@@ -27,7 +27,9 @@
             <tr>
               <td class="duplicates-table-text ">{{total_duplicate_records}} potential duplicate Verbal Autopsies</td>
               <td><a class="btn btn-primary" href="{% url 'data_cleanup:download_all' %}"><i class="icon-download"></i>Download All</a></td>
-              <td><a class="btn btn-danger" href="{% url 'data_management:delete_all' %}"><i class="icon-trash"></i>Delete All</a></td>
+              {% if perms.va_data_management.bulk_delete %}
+                <td><a class="btn btn-danger" href="{% url 'data_management:delete_all' %}"><i class="icon-trash"></i>Delete All</a></td>
+              {% endif %}
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
# Description
[VA-Explorer-247](https://github.com/VA-Explorer/va_explorer/issues/247)

In the UI, there is no permissions check for showing the "Delete All" button within Data Cleanup. Because of this, the "Delete All" button is shown for Data Managers, who do not have the relevant permission. This PR adds the relevant permissions check in the Django template. 

## (Bugfix) How to Replicate

1. Log in as a Data Manager
2. Click on http://0.0.0.0:8000/va_data_cleanup/
3. Observe the the "Delete All" button is present

## (Bugfix) Solution
Add the relevant permissions check in the Django template. 

## Testing Recommendations
1. Log in as a Data Manager
2. Click on http://0.0.0.0:8000/va_data_cleanup/
3. Observe the the "Delete All" button is not present
