### PR TITLE
265 fix dashboard demographics chart

### DIFF
--- a/va_explorer/static/js/dashboard.js
+++ b/va_explorer/static/js/dashboard.js
@@ -193,6 +193,12 @@ const dashboard = new Vue({
                     });
                     index = this.demographics.length - 1;
                 }
+                if (!this.demographics[index].hasOwnProperty("female")) {
+                    this.demographics[index].female = 0
+                }
+                if (!this.demographics[index].hasOwnProperty("male")) {
+                    this.demographics[index].male = 0
+                }
                 this.demographics[index].age_group = ageGroup === "neonate" ? "Neonate (< 28 days)" :
                     ageGroup === "child" ? "Child (≤ 12 years)" : "Adult (> 12 years)";
                 this.demographics[index].order = ageGroups.indexOf(ageGroup);

--- a/va_explorer/va_data_management/utils/loading.py
+++ b/va_explorer/va_data_management/utils/loading.py
@@ -1,4 +1,5 @@
 import logging
+import random
 
 import numpy as np
 import pandas as pd
@@ -142,7 +143,7 @@ def load_records_from_dataframe(record_df, random_locations=False, debug=True):
         # to determine location.
         # Otherwise, try assigning location based on hospital field.
         if random_locations:
-            user = field_workers.order_by("?").first()
+            user = random.choice(field_workers)
             va.location = user.location_restrictions.first()
         else:
             assign_va_location(va, location_map)

--- a/va_explorer/va_data_management/utils/validate.py
+++ b/va_explorer/va_data_management/utils/validate.py
@@ -53,26 +53,36 @@ def validate_vas_for_dashboard(verbal_autopsies):
         # age group can be determined from multiple fields, it's required for
         # filtering demographics
         if (
-            va.age_group != "adult"
-            and va.age_group != "neonate"
-            and va.age_group != "child"
+            va.isNeonatal != 1
+            and va.isNeonatal != 1.0
             and va.isNeonatal1 != 1
+            and va.isNeonatal1 != 1.0
+            and va.isNeonatal2 != 1
+            and va.isNeonatal2 != 1.0
+            and va.isChild != 1
+            and va.isChild != 1.0
             and va.isChild1 != 1
+            and va.isChild1 != 1.0
+            and va.isChild2 != 1
+            and va.isChild2 != 1.0
+            and va.isAdult != 1
+            and va.isAdult != 1.0
             and va.isAdult1 != 1
+            and va.isAdult1 != 1.0
+            and va.isAdult2 != 1
+            and va.isAdult2 != 1.0
         ):
-            try:
-                _ = int(float(va.ageInYears))
-            except:  # noqa E722 - Intent is to save to db, not do anything with exception
-                issue_text = "Warning: field age_group, no relevant data was found in \
-                    fields; age_group, isNeonatal1, isChild1, isAdult1, or ageInYears."
-                issue = CauseCodingIssue(
-                    verbalautopsy_id=va.id,
-                    text=issue_text,
-                    severity="warning",
-                    algorithm="",
-                    settings="",
-                )
-                issues.append(issue)
+            issue_text = "Warning: field age_group, no relevant data was found in \
+                fields; isNeonatal, isNeonatal1, isNeonatal2, isChild, isChild1, \
+                isChild2 isAdult, isAdult1, or isAdult2."
+            issue = CauseCodingIssue(
+                verbalautopsy_id=va.id,
+                text=issue_text,
+                severity="warning",
+                algorithm="",
+                settings="",
+            )
+            issues.append(issue)
 
         # Validate: location
         # location is used to display the record on the map


### PR DESCRIPTION
Resolves #265 

- Updates VA age group validation rules to match those used by the dashboard demographics chart. 
  - Determines age group using the fields `isNeonatal`, `isChild`, `isAdult` and their numbered variants such as `isNeonatal1` and `isNeonatal2`.
- Fixes a bug the `load_va_csv` admin command that causes the `random_location` mode to fail.
- Fixes a bug in the dashboard demographics chart so that it properly handles when an age group has no numerical data for at least one of male or female.
  - ex: `{ "age_group": "adult", "male": 1 }`