### PR TITLE
Replace refs to submissiondate with Id10012 (Interview date)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,7 +18,7 @@ REDIS_URL=redis://redis:6379/0
 # POSTGRES_PASSWORD=
 
 ## Internal Integrations
-PYCROSS_HOST=http://pycrossva:80
+PYCROSS_HOST=http://pycrossva:5001
 
 INTERVA_HOST=http://interva5:5002
 INTERVA_MALARIA=l

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-dcc02e52ccbb649b9febe9182abfa5e03c49be6c}
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost}
       DJANGO_DEFAULT_FROM_EMAIL: ${DJANGO_DEFAULT_FROM_EMAIL:-VA Explorer <noreply@vaexplorer.org>} 
-      PYCROSS_HOST: ${PYCROSS_HOST:-http://pycrossva:80}
+      PYCROSS_HOST: ${PYCROSS_HOST:-http://pycrossva:5001}
       INTERVA_HOST: ${INTERVA_HOST:-http://interva5:5002}
     volumes:
       - ./va_explorer_logs:/app/va_explorer/va_logs/logfiles

--- a/docs/training/general/common_actions.md
+++ b/docs/training/general/common_actions.md
@@ -31,7 +31,7 @@ actions you can take in VA Explorer, such as viewing PII and downloading data.
 These account settings are described in User Roles and Capabilities (link) To
 view your account profile:
 
-1. Click your name in the upper righthand corner of the navigation bar; a
+1. Click your name in the upper right-hand corner of the navigation bar; a
 dropdown menu will open.
 
 1. Click the "My Profile" option within the dropdown menu.
@@ -44,7 +44,7 @@ update user accounts.
 
 To change your password while signed into VA Explorer:
 
-1. Click your name in the upper righthand corner of the navigation bar; a
+1. Click your name in the upper right-hand corner of the navigation bar; a
 dropdown menu will open.
 
 1. Click the "Change Password" option within the dropdown menu.
@@ -82,8 +82,8 @@ page and directly above the heatmap. The global filters include:
     - How to Use
 
   * - Death Date
-    - View analytics for a specific date of death timeframe
-    - Choose the timeframe you want to explore from the Time Period dropdown
+    - View analytics for a specific date of death time frame
+    - Choose the time frame you want to explore from the Time Period dropdown
       menu (ex. Within 1 Month, Within 1 Year, or Custom)
 
   * - Cause of Death
@@ -135,21 +135,21 @@ page, you can search or filter available VAs with the following parameters:
   * - ID
     - The unique numeric identifier assigned to the specific VA in VA Explorer.
 
-  * - Submitted
-    - The date the VA was submitted. If your account does not have PII access,
-      you will see "Date Unknown.
+  * - Interviewed
+    - The date the VA interview was conducted. If your account does not have PII access,
+      you will see "Date Unknown".
 
   * - Facility
     - The facility where the VA was collected. If facility information is
-      missing, you will see "Location Unknown.
+      missing, you will see "Location Unknown".
 
   * - Deceased
     - The name of the deceased individual. If your account does not have PII
-      access, you will see "Subject Unknown.
+      access, you will see "Subject Unknown".
 
   * - Deathdate
     - The date of the individual’s death. If your account does not have PII
-      access, you will see "Date Unknown.
+      access, you will see "Date Unknown".
 
   * - Cause
     - The cause of death assigned by coding algorithm. If the VA has not yet

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,7 @@ requests==2.28.1
 pandas==1.5.1
 fuzzywuzzy==0.18.0
 python-Levenshtein==0.20.7
+tqdm==4.65.0
 
 # Django
 django==4.1.2

--- a/va_explorer/home/tests/test_views.py
+++ b/va_explorer/home/tests/test_views.py
@@ -28,23 +28,23 @@ def test_trends(user: User):
 
     today = date.today()
 
-    # Other submission dates
+    # Other interview dates
     today_minus_one_month = datetime.now() - relativedelta(months=1)
     today_minus_six_months = datetime.now() - relativedelta(months=6)
     today_minus_one_year = datetime.now() - relativedelta(months=12)
 
     # VAs collected today = 2
-    coded_va = VerbalAutopsyFactory.create(submissiondate=today, Id10023=today)
-    uncoded_va = VerbalAutopsyFactory.create(submissiondate=today, Id10023=today)
+    coded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
+    uncoded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
     # VAs collected at other points in time = 3
     VerbalAutopsyFactory.create(
-        submissiondate=today_minus_one_month, Id10023=today_minus_one_month
+        Id10012=today_minus_one_month, Id10023=today_minus_one_month
     )
     VerbalAutopsyFactory.create(
-        submissiondate=today_minus_six_months, Id10023=today_minus_six_months
+        Id10012=today_minus_six_months, Id10023=today_minus_six_months
     )
     VerbalAutopsyFactory.create(
-        submissiondate=today_minus_one_year, Id10023=today_minus_one_year
+        Id10012=today_minus_one_year, Id10023=today_minus_one_year
     )
 
     CauseOfDeathFactory.create(cause="Indeterminate", verbalautopsy=coded_va)
@@ -126,7 +126,7 @@ def test_trends(user: User):
     assert len(json_data["issueList"]) == 4
     assert uncoded_va.Id10017 in json_data["issueList"][0]["deceased"]
     assert json_data["additionalIssues"] == 0
-    # VAs in indeterminate COD list includes VAs with inderminate COD
+    # VAs in indeterminate COD list includes VAs with indeterminate COD
     assert len(json_data["indeterminateCodList"]) == 1
     assert json_data["indeterminateCodList"][0]["id"] == coded_va.id
     assert json_data["additionalIndeterminateCods"] == 0

--- a/va_explorer/static/js/dashboard.js
+++ b/va_explorer/static/js/dashboard.js
@@ -207,7 +207,6 @@ const dashboard = new Vue({
             this.demographics.forEach(d => {
                 delete d.order;
             });
-            console.log(this.demographics)
 
             // display warning message if small sample size (allow user to stop these dialogs)
             if (!this.suppressWarning &&

--- a/va_explorer/static/js/dashboard.js
+++ b/va_explorer/static/js/dashboard.js
@@ -24,7 +24,7 @@ const dashboard = new Vue({
             uncoded_vas: 0,
             update_stats: {
                 last_update: 0,
-                last_submission: 0,
+                last_interview: 0,
             },
 
             // chart sizes
@@ -74,7 +74,7 @@ const dashboard = new Vue({
         highlightsSummaries() {
             return {
                 "Last Data Update": this.update_stats.last_update,
-                "Last VA Submission": this.update_stats.last_submission,
+                "Last VA Interview": this.update_stats.last_interview,
                 "Coded VAs": d3.sum(this.COD_grouping.map(item => item.count)),
                 "Uncoded VAs": this.uncoded_vas,
             }
@@ -207,6 +207,7 @@ const dashboard = new Vue({
             this.demographics.forEach(d => {
                 delete d.order;
             });
+            console.log(this.demographics)
 
             // display warning message if small sample size (allow user to stop these dialogs)
             if (!this.suppressWarning &&

--- a/va_explorer/static/js/home.js
+++ b/va_explorer/static/js/home.js
@@ -7,10 +7,10 @@ GRAPH_OPTIONS = {
 BORDER_COLOR = "#037BFE"
 
 const setVATrendsTableData = (vaTableData) => {
-  document.getElementById('submitted-past-24-hours').innerHTML = vaTableData.collected["24"];
-  document.getElementById('submitted-past-week').innerHTML = vaTableData.collected["1 week"];
-  document.getElementById('submitted-past-month').innerHTML =  vaTableData.collected["1 month"];
-  document.getElementById('submitted-overall').innerHTML = vaTableData.collected["Overall"];
+  document.getElementById('interviewed-past-24-hours').innerHTML = vaTableData.collected["24"];
+  document.getElementById('interviewed-past-week').innerHTML = vaTableData.collected["1 week"];
+  document.getElementById('interviewed-past-month').innerHTML =  vaTableData.collected["1 month"];
+  document.getElementById('interviewed-overall').innerHTML = vaTableData.collected["Overall"];
 
   document.getElementById('coded-past-24-hours').innerHTML = vaTableData.coded["24"];
   document.getElementById('coded-past-week').innerHTML = vaTableData.coded["1 week"];
@@ -28,7 +28,7 @@ const setVARow = (root, row, isFieldWorker) => {
     root.insertAdjacentHTML('beforebegin',
 `<tr>
         <td>${row.id}</td>
-        <td>${row.submitted}</td>
+        <td>${row.interviewed}</td>
         <td>${row.facility}</td>
         <td>${row.deceased}</td>
         <td>${row.dod}</td>
@@ -43,7 +43,7 @@ const setVARow = (root, row, isFieldWorker) => {
     root.insertAdjacentHTML('beforebegin',
 `<tr>
         <td>${row.id}</td>
-        <td>${row.submitted}</td>
+        <td>${row.interviewed}</td>
         <td>${row.interviewer}</td>
         <td>${row.facility}</td>
         <td>${row.deceased}</td>
@@ -82,11 +82,11 @@ const setVAChart = (x, y, ctx) => {
 }
 
 const setVACharts = (graphData) => {
-  const submittedCtx = document.getElementById("submittedChart").getContext("2d");
+  const interviewedCtx = document.getElementById("interviewedChart").getContext("2d");
   const codedCtx = document.getElementById("codedChart").getContext("2d");
   const notYetCodedCtx = document.getElementById("notYetCodedChart").getContext("2d");
 
-  setVAChart(graphData.collected.x, graphData.collected.y, submittedCtx);
+  setVAChart(graphData.collected.x, graphData.collected.y, interviewedCtx);
   setVAChart(graphData.coded.x, graphData.coded.y,codedCtx);
   setVAChart(graphData.uncoded.x, graphData.uncoded.y, notYetCodedCtx);
 }

--- a/va_explorer/templates/home/index.html
+++ b/va_explorer/templates/home/index.html
@@ -23,17 +23,17 @@
           <th scope="col">1 week</th>
           <th scope="col">1 month</th>
           <th scope="col">Overall</th>
-          <th scope="col">Submission Trends</th>
+          <th scope="col">Interview Trends</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <th scope="row">Submitted</th>
-          <td id="submitted-past-24-hours"></td>
-          <td id="submitted-past-week"></td>
-          <td id="submitted-past-month"></td>
-          <td id="submitted-overall"></td>
-          <td><canvas id="submittedChart"></canvas></td>
+          <th scope="row">Interviewed</th>
+          <td id="interviewed-past-24-hours"></td>
+          <td id="interviewed-past-week"></td>
+          <td id="interviewed-past-month"></td>
+          <td id="interviewed-overall"></td>
+          <td><canvas id="interviewedChart"></canvas></td>
         </tr>
         <tr>
           <th scope="row">Coded</th>
@@ -75,7 +75,7 @@
       <thead>
         <tr>
           <th>ID</th>
-          <th>Submitted</th>
+          <th>Interviewed</th>
           {% if not user.is_fieldworker %}<th>Interviewer</th>{% endif %}
           <th>Facility</th>
           <th>Deceased</th>
@@ -109,7 +109,7 @@
       <thead>
         <tr>
           <th>ID</th>
-          <th>Submitted</th>
+          <th>Interviewed</th>
           {% if not user.is_fieldworker %}<th>Interviewer</th>{% endif %}
           <th>Facility</th>
           <th>Deceased</th>

--- a/va_explorer/templates/home/index.html
+++ b/va_explorer/templates/home/index.html
@@ -6,7 +6,7 @@
   <div class="col">
     {% include 'partials/_va_update_stats.html' %}
     {% if not user.is_fieldworker %}
-      {% if last_update or last_submission %}
+      {% if last_update or last_interview %}
         <h2 class="mb-4">VA Collection Overview for {{ locations }}</h2>
       {% else %}
         <h2 class="mb-4">No VAs found for {{ locations }}</h2>

--- a/va_explorer/templates/partials/_va_table.html
+++ b/va_explorer/templates/partials/_va_table.html
@@ -4,11 +4,11 @@
   <thead>
     <tr>
       <th><a href="?{% sort_url 'id' direction='-' %}">ID</a></th>
-      <th><a href="?{% sort_url 'submissiondate' direction='-' %}">Submitted</a></th>
+      <th><a href="?{% sort_url 'Id10012' direction='-' %}">Interviewed</a></th>
       {% if not user.is_fieldworker %}
-        <th><a href="?{% sort_url 'submissiondate' direction='-' %}">Interviewer</a></th>
+        <th><a href="?{% sort_url 'Id10010' direction='-' %}">Interviewer</a></th>
       {% endif %}
-      <th><a href="?{% sort_url 'Id10010' direction='-' %}">Facility</a></th>
+      <th><a href="?{% sort_url 'facility' direction='-' %}">Facility</a></th>
       <th><a href="?{% sort_url 'deceased' direction='-' %}">Deceased</a></th>
       <th><a href="?{% sort_url 'Id10023' direction='-' %}">Deathdate</a></th>
       <th><a href="?{% sort_url 'cause' direction='-' %}">Cause</a></th>
@@ -36,7 +36,7 @@
       {% for va in va_list %}
         <tr>
           <td>{{ va.id }}</td>
-          <td>{% pii_filter "submissiondate" va.submitted|default:"Date Unknown" %}</td>
+          <td>{% pii_filter "Id10012" va.interviewed|default:"Date Unknown" %}</td>
           {% if not user.is_fieldworker %}
             <td>{% pii_filter "Id10010" va.interviewer|default:"Not Listed" %}</td>
           {% endif %}

--- a/va_explorer/templates/partials/_va_update_stats.html
+++ b/va_explorer/templates/partials/_va_update_stats.html
@@ -1,5 +1,5 @@
 {% load va_explorer_tags %}
-{% if last_update or last_submission %}
+{% if last_update or last_interview %}
   <div class="row">
     {% if last_update %}
         <p class='msg-header'> <b>Last Data Update:</b> {{ last_update }}</p>
@@ -7,8 +7,8 @@
         <p class='msg-header'>No VAs found</p>
     {% endif %}
 
-    {% if last_submission %}
-        <p class='msg-header'><b>Last VA submission:</b> {{ last_submission }}</p>
+    {% if last_interview %}
+        <p class='msg-header'><b>Last VA Interview:</b> {{ last_interview }}</p>
     {% endif %}
 
     {% if AUTO_DETECT_DUPLICATES %}

--- a/va_explorer/va_analytics/filters.py
+++ b/va_explorer/va_analytics/filters.py
@@ -24,13 +24,13 @@ class SupervisionFilter(FilterSet):
         field_name="location__name", lookup_expr="icontains", label="Facility"
     )
     start_date = DateFilter(
-        field_name="submissiondate",
+        field_name="Id10012",
         lookup_expr="gte",
         label="Earliest Date",
         widget=DateInput(attrs={"class": "datepicker"}),
     )
     end_date = DateFilter(
-        field_name="submissiondate",
+        field_name="Id10012",
         lookup_expr="lte",
         label="Latest Date",
         widget=DateInput(attrs={"class": "datepicker"}),

--- a/va_explorer/va_analytics/tests/test_views.py
+++ b/va_explorer/va_analytics/tests/test_views.py
@@ -87,12 +87,12 @@ class TestSupervisionView:
         VerbalAutopsyFactory.create(
             location=facility1,
             Id10010=username,
-            submissiondate=str(date.today() - timedelta(days=8)),
+            Id10012=str(date.today() - timedelta(days=8)),
         )
         VerbalAutopsyFactory.create(
             location=facility1,
             Id10010=username,
-            submissiondate=str(date.today()),
+            Id10012=str(date.today()),
         )
 
         request = rf.get("/va_analytics/supervision/")
@@ -103,5 +103,5 @@ class TestSupervisionView:
         supervision_stats = response.context_data["supervision_stats"][0]
         assert supervision_stats["Total VAs"] == 2
         assert supervision_stats["Weeks of Data"] == 2
-        assert supervision_stats["Last Submission"] == date.today()
+        assert supervision_stats["Last Interview"] == date.today()
         assert supervision_stats["VAs / week"] == 1.0

--- a/va_explorer/va_analytics/utils/loading.py
+++ b/va_explorer/va_analytics/utils/loading.py
@@ -64,7 +64,7 @@ def load_va_data(
 ):
     user_vas = user.verbal_autopsies(date_cutoff=start_date, end_date=end_date)
 
-    # get stats on last update and last va submission date
+    # get stats on last update and last va interview date
     update_stats = get_va_summary_stats(user_vas)
     if len(questions_to_autodetect_duplicates()) > 0:
         update_stats["duplicates"] = user_vas.filter(duplicate=True).count()

--- a/va_explorer/va_data_cleanup/views.py
+++ b/va_explorer/va_data_cleanup/views.py
@@ -50,7 +50,7 @@ class DataCleanupIndexView(CustomAuthMixin, PermissionRequiredMixin, ListView):
             {
                 "id": va.id,
                 "interviewer": va.Id10010,
-                "submitted": parse_date(va.submissiondate),
+                "interviewed": parse_date(va.Id10012),
                 "dod": parse_date(va.Id10023) if (va.Id10023 != "dk") else "Unknown",
                 "facility": va.location.name if va.location else "",
                 "deceased": va.deceased,

--- a/va_explorer/va_data_management/management/commands/fake_current_va_dates.py
+++ b/va_explorer/va_data_management/management/commands/fake_current_va_dates.py
@@ -26,9 +26,6 @@ class Command(BaseCommand):
         # TODO: The date fields should really be stored as dates in the database,
         #       his fails on different string formats for dates
         # TODO: We need a clear picture of all the date fields in the system
-        # TODO: 10011 is labeled as "start" and 10012 is labeled as "today" in the
-        #       questionnaire, are those collection dates?
-        # TODO: submissiondate seems all the same in one of the sample files
         most_recent = max(
             [
                 datetime.strptime(date, "%m/%d/%y").date()

--- a/va_explorer/va_data_management/management/commands/randomize_va_dates.py
+++ b/va_explorer/va_data_management/management/commands/randomize_va_dates.py
@@ -6,6 +6,7 @@ from random import randint
 import pytz
 from django.core.management.base import BaseCommand
 from django.utils import timezone
+from tqdm import tqdm
 
 from va_explorer.va_data_management.models import VerbalAutopsy
 
@@ -36,8 +37,10 @@ class Command(BaseCommand):
             dates_list.append(date)
 
         dates_list.sort()
-        for va, new_date in zip(VerbalAutopsy.objects.all(), dates_list):
+        for va, new_date in tqdm(
+            zip(VerbalAutopsy.objects.all(), dates_list), total=count
+        ):
             # Set Id10023 and created and updated all to same date
-            va.Id10023 = va.created = va.updated = va.submissiondate = new_date
+            va.Id10023 = va.created = va.updated = va.Id10012 = new_date
             va.skip_history_when_saving = True
             va.save()

--- a/va_explorer/va_data_management/tests/test_date_parsing.py
+++ b/va_explorer/va_data_management/tests/test_date_parsing.py
@@ -2,25 +2,25 @@ import pytest
 from numpy import nan
 
 from va_explorer.va_data_management.models import VerbalAutopsy
-from va_explorer.va_data_management.utils.date_parsing import get_submissiondate
+from va_explorer.va_data_management.utils.date_parsing import get_interview_date
 
 pytestmark = pytest.mark.django_db
 
 
-# ensure that when submissiondate field not available, Id10011 is used to
+# ensure that when interview date field not available, Id10011 is used to
 # determine date of submission
-def test_submissiondate_logic():
+def test_interview_date_logic():
     date1 = "2021-04-19T13:53:07.928Z"
     date2 = "2020-05-19T20:18:12.124+02:00"
     empty_string = "dk"
 
-    va1 = VerbalAutopsy(submissiondate=date1)
-    va2 = VerbalAutopsy(submissiondate=nan, Id10011=date2)
-    va3 = VerbalAutopsy(submissiondate="", Id10011="")
+    va1 = VerbalAutopsy(Id10012=date1)
+    va2 = VerbalAutopsy(Id10012=nan, Id10011=date2)
+    va3 = VerbalAutopsy(Id10012="", Id10011="")
 
-    date_res_1 = get_submissiondate(va1, parse=True, empty_string=empty_string)
-    date_res_2 = get_submissiondate(va2, parse=True, empty_string=empty_string)
-    date_res_3 = get_submissiondate(va3, parse=True, empty_string=empty_string)
+    date_res_1 = get_interview_date(va1, parse=True, empty_string=empty_string)
+    date_res_2 = get_interview_date(va2, parse=True, empty_string=empty_string)
+    date_res_3 = get_interview_date(va3, parse=True, empty_string=empty_string)
 
     assert date_res_1 == "2021-04-19"
     assert date_res_2 == "2020-05-19"

--- a/va_explorer/va_data_management/tests/test_date_parsing.py
+++ b/va_explorer/va_data_management/tests/test_date_parsing.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.django_db
 
 
 # ensure that when interview date field not available, Id10011 is used to
-# determine date of submission
+# determine date of interview
 def test_interview_date_logic():
     date1 = "2021-04-19T13:53:07.928Z"
     date2 = "2020-05-19T20:18:12.124+02:00"

--- a/va_explorer/va_data_management/utils/date_parsing.py
+++ b/va_explorer/va_data_management/utils/date_parsing.py
@@ -56,38 +56,38 @@ def to_dt(dates, utc=True):
     )
 
 
-# get submissiondate for multiple vas (supports df, queryset or list of vas).
-# First, checks for submissiondate. If empty, checks for va start date (Id10011).
+# get interview date for multiple vas (supports df, queryset or list of vas).
+# First, checks for Id10012 (interview). If empty, checks for va start date (Id10011).
 # If empty, returns empty_string
-def get_submissiondates(va_data, empty_string=None):
+def get_interview_dates(va_data, empty_string=None):
     # va_data is a dataframe - use vectorized logic
     if type(va_data) is pd.DataFrame:
         if not va_data.empty:
             assert "Id10011" in va_data.columns
-            if "submissiondate" not in va_data.columns:
+            if "Id10012" not in va_data.columns:
                 return va_data["Id10011"]
             else:
                 return np.where(
-                    ~empty_dates(va_data, "submissiondate"),
-                    va_data["submissiondate"],
+                    ~empty_dates(va_data, "Id10012"),
+                    va_data["Id10012"],
                     va_data["Id10011"],
                 )
 
-    # va_data is list of va objects. Iterate through & get individual submission dates
+    # va_data is list of va objects. Iterate through & get individual interview dates
     else:
-        return [get_submissiondate(va, empty_string=empty_string) for va in va_data]
+        return [get_interview_date(va, empty_string=empty_string) for va in va_data]
 
 
-# get submissiondate for single va object. Uses the same field logic as above.
-def get_submissiondate(va_data, empty_string=None, parse=False):
-    if pd.isna(va_data.submissiondate) or va_data.submissiondate in ["", "nan", "dk"]:
+# get interview date for single va object. Uses the same field logic as above.
+def get_interview_date(va_data, empty_string=None, parse=False):
+    if pd.isna(va_data.Id10012) or va_data.Id10012 in ["", "nan", "dk"]:
         if not pd.isna(va_data.Id10011) and va_data.Id10011 not in ["", "nan", "dk"]:
             return parse_date(va_data.Id10011) if parse else va_data.Id10011
         else:
             return empty_string
     else:
-        return parse_date(va_data.submissiondate) if parse else va_data.submissiondate
+        return parse_date(va_data.Id10012) if parse else va_data.Id10012
 
 
-def empty_dates(va_df, date_col="submissiondate", null_strings=NULL_STRINGS):
+def empty_dates(va_df, date_col="Id10012", null_strings=NULL_STRINGS):
     return (pd.isna(va_df[date_col])) | (va_df[date_col].isin(null_strings))

--- a/va_explorer/va_data_management/utils/loading.py
+++ b/va_explorer/va_data_management/utils/loading.py
@@ -83,14 +83,14 @@ def load_records_from_dataframe(record_df, random_locations=False, debug=True):
 
     # if random locations, assign random locations via a random field worker.
     if random_locations:
-        field_workers = [ u for u in User.objects.all() if u.is_fieldworker() ] 
+        field_workers = [u for u in User.objects.all() if u.is_fieldworker()]
         if len(field_workers) <= 1:
             print(
                 "WARNING: no field workers in system. \
                 Generating random ones now..."
             )
             make_field_workers_for_facilities()
-            field_workers = [ u for u in User.objects.all() if u.is_fieldworker() ] 
+            field_workers = [u for u in User.objects.all() if u.is_fieldworker()]
 
     # pull in all existing VA instanceIDs from db for de-duping purposes
     print("pulling in instance ids...")
@@ -129,15 +129,15 @@ def load_records_from_dataframe(record_df, random_locations=False, debug=True):
             )
         va.Id10023 = parsed_date
 
-        # Try to parse submission date as as datetime. Otherwise, record string and
+        # Try to parse interview date as as datetime. Otherwise, record string and
         # add record issue during validation
-        parsed_sub_date = parse_date(va.submissiondate, strict=False)
+        parsed_sub_date = parse_date(va.Id10012, strict=False)
         if logger:
             logger.info(
                 f"va_id: {va_id} - Parsed {parsed_sub_date} as \
-                Submission Date from {va.submissiondate}"
+                Interview Date from {va.Id10012}"
             )
-        va.submissiondate = parsed_sub_date
+        va.Id10012 = parsed_sub_date
 
         # if random_locations, assign random field worker to VA which can be used
         # to determine location.
@@ -317,7 +317,7 @@ def get_va_summary_stats(vas, filter_fields=False):
     if not stats:
         stats = vas.aggregate(
             last_update=Max("created"),
-            last_submission=Max("submissiondate"),
+            last_interview=Max("Id10012"),
             total_vas=Count("id"),
         )
         cache.set("va_summary_stats", stats, timeout=60 * 60)
@@ -330,11 +330,11 @@ def get_va_summary_stats(vas, filter_fields=False):
     if stats["last_update"] and type(stats["last_update"]) is not str:
         stats["last_update"] = stats["last_update"].strftime("%Y-%m-%d")
 
-    if stats["last_submission"]:
-        # Handle datetimes and Text (which can occur since submissiondate is TextField)
-        if type(stats["last_submission"]) is not str:
-            stats["last_submission"] = stats["last_submission"].strftime("%Y-%m-%d")
+    if stats["last_interview"]:
+        # Handle datetimes and Text (which can occur since interview is TextField)
+        if type(stats["last_interview"]) is not str:
+            stats["last_interview"] = stats["last_interview"].strftime("%Y-%m-%d")
         else:
-            stats["last_submission"] = parse_date(stats["last_submission"])
+            stats["last_interview"] = parse_date(stats["last_interview"])
     return stats
     # TODO is it likely or possible to return no VAs? if yes, return empty stats

--- a/va_explorer/va_data_management/views.py
+++ b/va_explorer/va_data_management/views.py
@@ -54,7 +54,7 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
                 "causes__cause",
                 "Id10023",
                 "Id10010",
-                "submissiondate",
+                "Id10012",
                 "deceased",
                 errors=Count(
                     F("coding_issues"), filter=Q(coding_issues__severity="error")
@@ -76,7 +76,7 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
             "dod": "Id10023",
             "facility": "location__name",
             "cause": "causes__cause",
-            "submitted": "submissiondate",
+            "interviewed": "Id10012",
             "deceased": "deceased",
         }
         sort_field = sort_key_to_field.get(sort_key, sort_key)
@@ -125,7 +125,7 @@ class Index(CustomAuthMixin, PermissionRequiredMixin, ListView):
                 "id": va["id"],
                 "deceased": va["deceased"],
                 "interviewer": va["Id10010"],
-                "submitted": parse_date(va["submissiondate"]),
+                "interviewed": parse_date(va["Id10012"]),
                 "dod": parse_date(va["Id10023"])
                 if (va["Id10023"] != "dk")
                 else "Unknown",


### PR DESCRIPTION
This PR replaces all functional references to `va.submissiondate` with `va.Id10012` (the interview date instead) for reasons mentioned in #263.

- Updates homepage charts & dashboard to use Id10012 and changes language from "submitted" to "interviewed" and similar tweaks
- Updates data update boxes on home & dashboard to use `last_interview` instead of `last_submission`
- Updates supervision page to calculate interviews based off interview date instead of submission date
- Updates other modules like data management, VA partial table, cleanup, etc to use the correct field
- Updates management commands that create fake dates for testing/demo to set Interview date instead of submission
- Fixes 2 small bugs found while implementing, 1 preventing correct sorting on the VA table partial, the other preventing local runs of `run_coding_algorithms`

Closes #263 