### PR TITLE
Support Kobo Pagination & make instancename workaround more robust

### DIFF
--- a/docs/usage/integrations.md
+++ b/docs/usage/integrations.md
@@ -12,6 +12,56 @@ integrations as well as details on how to enable them in VA Explorer if needed.
   - pyCrossVA
   - InterVA5
 
+## Networking
+
+When integrating services with VA Explorer, operators should be aware of additional
+networking configuration if multiple docker-compose services are run on the same server.
+
+docker-compose creates all containers that are part of its compose file under a
+default bridge network to allow intercommunication for that service. This setup
+does not allow one set of docker-compose managed containers to talk to another
+(VA Explorer -> ODK for example) by default.
+
+To support this use case, operators can create an external bridge network and
+connect it to the necessary containers like so:
+
+```sh
+docker network create <external network name>
+docker network connect <external network name> va_explorer_django_1
+docker network connect <external network name> <other service's container name>
+```
+
+VA Explorer provides some additional network configuration to enable use of this
+external network via `.env` variables:
+
+````{eval-rst}
+.. tabularcolumns:: |p{\dimexpr 0.25\linewidth-2\tabcolsep}|p{\dimexpr 0.25\linewidth-2\tabcolsep}|p{\dimexpr 0.50\linewidth-2\tabcolsep}|
+.. flat-table:: List of all configuration options when integrating with ODK Central, plus default values and descriptions for each
+  :widths: 3 3 5
+  :header-rows: 1
+  :stub-columns: 1
+
+  * - Variable Name
+    - Default Value
+    - Description
+
+  * - ``USE_GATEWAY``
+    - ``False``
+    - ``True`` or ``False``. Used by VA Explorer determine if an external docker
+      network should be used by integrations. Defaults to `False`.
+
+  * - ``DOCKER_GATEWAY``
+    - ``""``
+    - An http scheme (``http://`` or ``https://``) followed by the IP address
+      given by ``docker network inspect <external network name>`` command. Found
+      as the ``IPAM.Config.Gateway`` property's value. Used by VA Explorer as an
+      adaptor for HOST value of the service you wish to integrate with. Defaults
+      to an empty string.
+````
+
+These `.env` variables should supplement the variables described below in whichever
+service(s) you wish to integrate with.
+
 ## ODK Central
 
 VA Explorer supports integration with {term}`ODK` Central to provide both manual and

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -9,7 +9,7 @@ pytest-django==4.5.2
 coverage==7.0.1
 django-coverage-plugin==3.0.0
 factory-boy==3.2.1
-selenium==4.5.0
+selenium==4.13.0
 requests-mock==1.10.0
 pre-commit==2.20.0
 time-machine==2.8.2

--- a/va_explorer/va_data_management/management/commands/import_from_kobo.py
+++ b/va_explorer/va_data_management/management/commands/import_from_kobo.py
@@ -5,6 +5,8 @@ from django.core.management.base import BaseCommand
 from va_explorer.va_data_management.utils.kobo import download_responses
 from va_explorer.va_data_management.utils.loading import load_records_from_dataframe
 
+BATCH_SIZE = 5000
+
 
 class Command(BaseCommand):
     help = "Loads verbal autopsy data from Kobo Toolbox into the database"
@@ -30,21 +32,40 @@ class Command(BaseCommand):
 
         if not token or not asset_id:
             self.stderr.write(
-                "Must specify either --token and --asset_id arguments or " \
+                "Must specify either --token and --asset_id arguments or "
                 "KOBO_API_TOKEN and KOBO_ASSET_ID environment variables."
             )
             return
 
-        forms = download_responses(token, asset_id)
+        # Make an initial call and loop if necessary
+        forms, next_page = download_responses(token, asset_id, BATCH_SIZE, None)
         results = load_records_from_dataframe(forms)
 
         num_created = len(results["created"])
         num_ignored = len(results["ignored"])
         num_outdated = len(results["outdated"])
+        num_corrected = len(results["corrected"])
         num_invalid = len(results["removed"])
+        pages_processed = 1
+
+        while next_page is not None:
+            forms, next_page = download_responses(
+                token, asset_id, BATCH_SIZE, next_page
+            )
+            results = load_records_from_dataframe(forms)
+            num_created = num_created + len(results["created"])
+            num_ignored = num_ignored + len(results["ignored"])
+            num_outdated = num_outdated + len(results["outdated"])
+            num_corrected = num_corrected + len(results["corrected"])
+            num_invalid = num_invalid + len(results["removed"])
+            pages_processed = pages_processed + 1
+            self.stdout.write(
+                "Processed Additional Page. " f"{pages_processed} processed total.."
+            )
 
         self.stdout.write(
-            f"Loaded {num_created} verbal autopsies from Kobo " \
-            f"({num_ignored} ignored, {num_outdated} overwritten, " \
+            f"Loaded {num_created} verbal autopsies from Kobo\n"
+            f"{num_corrected} required correction in order to import\n"
+            f"({num_ignored} ignored, {num_outdated} overwritten, "
             f"{num_invalid} removed as invalid)"
         )

--- a/va_explorer/va_data_management/tests/test-duplicate-input-data.csv
+++ b/va_explorer/va_data_management/tests/test-duplicate-input-data.csv
@@ -1,6 +1,6 @@
-instanceid,instancename,Id10017,Id10018,Id10019,Id10020,Id10021,Id10022,Id10023
-10,_Dec---Bob_Jones---2021-03-22,Bob,Jones,Male,Yes,dk,Yes,dk
-11,_Dec---Bob_Jones---2021-03-22,Bob,Jones,Male,Yes,dk,Yes,dk
-12,_Dec---Cat_Smith---2021-03-22,Cat,Smith,Female,Yes,dk,Yes,dk
-13,_Dec---Cat_Smith---2021-03-22,Cat,Smith,Female,Yes,dk,Yes,dk
-14,_Dec---Cat_Smith---2021-03-22,Cat,Smith,Female,No,dk,No,dk
+instanceid,instancename,Id10017,Id10018,Id10012,Id10019,Id10020,Id10021,Id10022,Id10023
+10,_Dec---Bob_Jones---2021-03-22,Bob,Jones,2021-03-22,Male,Yes,dk,Yes,dk
+11,_Dec---Bob_Jones---2021-03-22,Bob,Jones,2021-03-22,Male,Yes,dk,Yes,dk
+12,_Dec---Cat_Smith---2021-03-22,Cat,Smith,2021-03-22,Female,Yes,dk,Yes,dk
+13,_Dec---Cat_Smith---2021-03-22,Cat,Smith,2021-03-22,Female,Yes,dk,Yes,dk
+14,_Dec---Cat_Smith---2021-03-22,Cat,Smith,2021-03-22,Female,No,dk,No,dk

--- a/va_explorer/va_data_management/tests/test-input-data.csv
+++ b/va_explorer/va_data_management/tests/test-input-data.csv
@@ -1,4 +1,4 @@
-instanceid,instancename,---Id10007
-instance1,_Dec---name1---2021-03-22,name1
-instance2,_Dec---name2---2021-03-22,name2
-instance3,_Dec---name3---2021-03-22,name3
+instanceid,instancename,Id10017,Id10018,Id10012,---Id10007
+instance1,_Dec---name1---2021-03-22,name,1,2021-03-22,name1
+instance2,_Dec---name2---2021-03-22,name,1,2021-03-22,name2
+instance3,_Dec---name3---2021-03-22,name,1,2021-03-22,name3

--- a/va_explorer/va_data_management/tests/test_loading.py
+++ b/va_explorer/va_data_management/tests/test_loading.py
@@ -19,13 +19,19 @@ def test_loading_from_dataframe():
     data = [
         {
             "instanceid": "instance1",
-            "instancename": "_Dec---name 1---2021-03-22",
+            "Id10017": "name",
+            "Id10018": "1",
+            "Id10012": "2021-03-21",
+            "instancename": "_Dec---name 1---2021-03-21",
             "testing-dashes-Id10007": "name 1",
             "Id10023": "03/01/2021",
             "hospital": "test location",
         },
         {
             "instanceid": "instance2",
+            "Id10017": "name",
+            "Id10018": "2",
+            "Id10012": "2021-03-22",
             "instancename": "_Dec---name 2---2021-03-22",
             "testing-dashes-Id10007": "name 2",
             "Id10023": "dk",
@@ -57,11 +63,17 @@ def test_loading_from_dataframe_with_ignored():
     data = [
         {
             "instanceid": "instance1",
+            "Id10017": "name",
+            "Id10018": "1",
+            "Id10012": "2021-03-21",
             "testing-dashes-Id10007": "name 1",
-            "instancename": "_Dec---name 1---2021-03-22",
+            "instancename": "_Dec---name 1---2021-03-21",
         },
         {
             "instanceid": "instance2",
+            "Id10017": "name",
+            "Id10018": "2",
+            "Id10012": "2021-03-22",
             "testing-dashes-Id10007": "name 2",
             "instancename": "_Dec---name 2---2021-03-22",
         },
@@ -81,13 +93,19 @@ def test_loading_from_dataframe_with_ignored():
     data = [
         {
             "instanceid": "instance1",
+            "Id10017": "name",
+            "Id10018": "1",
+            "Id10012": "2021-03-21",
             "testing-dashes-Id10007": "name 1",
-            "instancename": "_Dec---name 1---2021-03-22",
+            "instancename": "_Dec---name 1---2021-03-21",
         },
         {
             "instanceid": "instance4",
+            "Id10017": "name",
+            "Id10018": "4",
+            "Id10012": "2021-03-24",
             "testing-dashes-Id10007": "name 4",
-            "instancename": "_Dec---name 4---2021-03-22",
+            "instancename": "_Dec---name 4---2021-03-24",
         },
     ]
 
@@ -109,12 +127,18 @@ def test_loading_from_dataframe_with_key():
     data = [
         {
             "key": "instance1",
-            "instancename": "_Dec---name 1---2021-03-22",
+            "Id10017": "name",
+            "Id10018": "1",
+            "Id10012": "2021-03-21",
+            "instancename": "_Dec---name 1---2021-03-21",
             "testing-dashes-Id10007": "name 1",
             "hospital": "test location",
         },
         {
             "key": "instance2",
+            "Id10017": "name",
+            "Id10018": "2",
+            "Id10012": "2021-03-22",
             "testing-dashes-Id10007": "name 2",
             "instancename": "_Dec---name 2---2021-03-22",
             "hospital": "home",
@@ -166,7 +190,7 @@ def test_load_va_csv_command():
 
 def test_loading_duplicate_vas(settings):
     settings.QUESTIONS_TO_AUTODETECT_DUPLICATES = (
-        "Id10017, Id10018, Id10019, Id10020, Id10021, Id10022, Id10023"
+        "Id10017, Id10018, Id10012, Id10019, Id10020, Id10021, Id10022, Id10023"
     )
 
     # va1 matches 2 records in 'test-duplicate-input-data.csv'
@@ -175,6 +199,7 @@ def test_loading_duplicate_vas(settings):
     va1 = VerbalAutopsyFactory.create(
         Id10017="Bob",
         Id10018="Jones",
+        Id10012="2021-03-22",
         Id10019="Male",
         Id10020="Yes",
         Id10021="dk",
@@ -188,6 +213,7 @@ def test_loading_duplicate_vas(settings):
     va2 = VerbalAutopsyFactory.create(
         Id10017="Nate",
         Id10018="Grey",
+        Id10012="2012-03-22",
         Id10019="Male",
         Id10020="Yes",
         Id10021="dk",

--- a/va_explorer/va_data_management/utils/kobo.py
+++ b/va_explorer/va_data_management/utils/kobo.py
@@ -38,7 +38,7 @@ def get_kobo_api_token(username, password):
     return {"Authorization": f"Token {token}"}
 
 
-def download_responses(token, asset_id, batch_size, next_page):
+def download_responses(token, asset_id, batch_size=5000, next_page=None):
     if not token or not asset_id:
         raise AttributeError(
             "Must specify either --token and --asset_id arguments or \

--- a/va_explorer/va_data_management/utils/kobo.py
+++ b/va_explorer/va_data_management/utils/kobo.py
@@ -7,7 +7,7 @@ from requests.auth import HTTPBasicAuth
 
 env = environ.Env()
 USE_GATEWAY = env.bool("USE_GATEWAY", default=False)
-KOBO_HOST = env("KOBO_HOST", default="example.com")
+KOBO_HOST = env("KOBO_HOST", default="http://127.0.0.1:6001")
 # Don't verify localhost (self-signed cert)
 SSL_VERIFY = env.bool("KOBO_SSL_VERIFY", default=("localhost" in KOBO_HOST))
 

--- a/va_explorer/va_data_management/utils/kobo.py
+++ b/va_explorer/va_data_management/utils/kobo.py
@@ -1,12 +1,15 @@
+from urllib.parse import urlparse
+
 import environ
 import pandas as pd
 import requests
 from requests.auth import HTTPBasicAuth
 
 env = environ.Env()
-KOBO_HOST = env("KOBO_HOST", default="http://127.0.0.1:5003")
+USE_GATEWAY = env.bool("USE_GATEWAY", default=False)
+KOBO_HOST = env("KOBO_HOST", default="example.com")
 # Don't verify localhost (self-signed cert)
-SSL_VERIFY = env.bool("KOBO_SSL_VERIFY", not KOBO_HOST.startswith("http://localhost"))
+SSL_VERIFY = env.bool("KOBO_SSL_VERIFY", default=("localhost" in KOBO_HOST))
 
 # TODO: Further support Kobo integration by creating an endpoint for VAs coming
 #       in via REST Services feature (uploaded as soon as they're filled out)
@@ -15,9 +18,19 @@ SSL_VERIFY = env.bool("KOBO_SSL_VERIFY", not KOBO_HOST.startswith("http://localh
 # Prefer usage of token over username password, but provide this util method
 # just in case
 def get_kobo_api_token(username, password):
-    url = f"{KOBO_HOST}/token/?format=json"
     basic = HTTPBasicAuth(username, password)
-    response = requests.get(url, auth=basic, verify=SSL_VERIFY)
+
+    # Support advanced networking setups by allowing explicit use of external
+    # docker network gateways
+    if USE_GATEWAY:
+        DOCKER_GATEWAY = env("DOCKER_GATEWAY", default="https://172.18.0.1")
+        url = f"{DOCKER_GATEWAY}/token/?format=json"
+        headers = {"Host": KOBO_HOST}
+        response = requests.get(url, headers=headers, auth=basic, verify=SSL_VERIFY)
+    else:
+        url = f"{KOBO_HOST}/token/?format=json"
+        response = requests.get(url, auth=basic, verify=SSL_VERIFY)
+
     response.raise_for_status()
     data = response.json()
 
@@ -25,20 +38,38 @@ def get_kobo_api_token(username, password):
     return {"Authorization": f"Token {token}"}
 
 
-def download_responses(token, asset_id):
+def download_responses(token, asset_id, batch_size, next_page):
     if not token or not asset_id:
         raise AttributeError(
             "Must specify either --token and --asset_id arguments or \
                 KOBO_API_TOKEN and KOBO_ASSET_ID environment variables."
         )
 
-    resource_uri = f"{KOBO_HOST}/api/v2/assets/{asset_id}/data.json"
-    auth_header = {"Authorization": f"Token {token}"}
-    response = requests.get(resource_uri, headers=auth_header, verify=SSL_VERIFY)
+    # Support advanced networking setups by allowing explicit use of external
+    # docker network gateways
+    params = "?format=json" + f"&limit={batch_size}" + "&start=0&sort={%22_id%22:-1}"
+    if USE_GATEWAY:
+        DOCKER_GATEWAY = env("DOCKER_GATEWAY", default="https://172.18.0.1")
+        if next_page is None:
+            resource_uri = f"{DOCKER_GATEWAY}/api/v2/assets/{asset_id}/data/{params}"
+        else:
+            next_info = urlparse(next_page)
+            resource_uri = f"{DOCKER_GATEWAY}{next_info.path}?{next_info.query}"
+        headers = {"Authorization": f"Token {token}", "Host": KOBO_HOST}
+    else:
+        resource_uri = (
+            f"{KOBO_HOST}/api/v2/assets/{asset_id}/data/{params}"
+            if next_page is None
+            else next_page
+        )
+        headers = {"Authorization": f"Token {token}"}
+
+    response = requests.get(resource_uri, headers=headers, verify=SSL_VERIFY)
     response.raise_for_status()
     data = response.json()
     if "results" in data:
         parsed_results = list()
+        next_results = data["next"]
         for result in data["results"]:
             parsed_data = {}
             # Kobo column heading are in format group/subgroup/field, keep only field
@@ -46,6 +77,6 @@ def download_responses(token, asset_id):
                 new_key = key.split("/")[-1] if "/" in key else key
                 parsed_data[new_key] = value
             parsed_results.append(parsed_data)
-        return pd.DataFrame(parsed_results)
+        return pd.DataFrame(parsed_results), next_results
     else:
-        return []
+        return pd.DataFrame([]), None


### PR DESCRIPTION
This PR
- Adds logic to `import_from_kobo.py` to support paginated downloads. Necessary if data in kobo is larger than max page size of 30k
- Adds logic to `kobo.py` to support an external docker network. Necessary if VA Explorer and the service one wished to integrate with (Kobo in this case) are both run docker-compose and both on the same server host.
  - Adds documentation explaining how to configure new network settings
- Adds logic to `loading.py` to handle VAs that may be missing `instancename` by implementing a workaround that requires `Id10017` (first name of deceased), `Id10018` (last name of deceased), and `Id10012` (date of interview), to construct one manually as a workaround. VAs missing still missing these minimal fields are considered invalid for the purposes of import.
  - Updates test data to handle these new field expectations
  