### PR TITLE
Add Scheduled Tasks and Celery Flower UI

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,8 @@ DJANGO_ALLOWED_HOSTS=localhost
 
 CELERY_BROKER_URL=redis://redis:6379/0
 REDIS_URL=redis://redis:6379/0
+CELERY_FLOWER_USER=!!!SET CELERY_FLOWER_USER!!!
+CELERY_FLOWER_PASSWORD=!!!SET CELERY_FLOWER_PASSWORD!!!
 
 ## Custom DB Connection Settings, only change if not using included postgres container
 # POSTGRES_HOST=
@@ -18,7 +20,7 @@ REDIS_URL=redis://redis:6379/0
 # POSTGRES_PASSWORD=
 
 ## Internal Integrations
-PYCROSS_HOST=http://pycrossva:5001
+PYCROSS_HOST=http://pycrossva:80
 
 INTERVA_HOST=http://interva5:5002
 INTERVA_MALARIA=l

--- a/compose/django/celery/flower/start
+++ b/compose/django/celery/flower/start
@@ -5,4 +5,4 @@ set -o nounset
 
 export DJANGO_SETTINGS_MODULE=config.settings.production
 
-celery -A config.celery_app.app flower -l INFO
+celery -A config.celery_app.app flower --basic_auth="${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}" -l INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     environment:
       EMAIL_URL: ${EMAIL_URL:-smtp://localhost:25}
       CELERY_BROKER_URL: ${CELERY_BROKER_URL:-redis://redis:6379/0}
+      CELERY_FLOWER_USER: ${CELERY_FLOWER_USER}
+      CELERY_FLOWER_PASSWORD: ${CELERY_FLOWER_PASSWORD}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
       POSTGRES_HOST: ${POSTGRES_HOST:-vapostgres}
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,8 @@ services:
   flower:
     <<: *django
     # Don't publish ports like django does.
-    ports: []
+    ports:
+      - "5555:5555"
     image: va_explorer/flower
     command: /start-celeryflower
 

--- a/docs/usage/getting_started/config.md
+++ b/docs/usage/getting_started/config.md
@@ -70,6 +70,16 @@ documented below.
       `Django caching solution <https://docs.djangoproject.com/en/4.1/topics/cache/>`_.
       Default allows VA Explorer to take advantage of same redis
       available as celery backend so is often the same value.
+
+  * - ``CELERY_FLOWER_USER``
+    - Not Set
+    - Value indicating the username needed by the basic auth prompt that shows when
+      attempting to access the celery flower interface. Not set by default.
+
+  * - ``CELERY_FLOWER_PASSWORD``
+    - Not Set
+    - Value indicating the password needed by the basic auth prompt that shows when
+      attempting to access the celery flower interface. Not set by default.
 ````
 
 % Comment: We break the table in half here because the pdf rendering was flying off the page

--- a/va_explorer/templates/home/index.html
+++ b/va_explorer/templates/home/index.html
@@ -60,20 +60,13 @@
 <div class="row mt-4">
   <div class="col">
     <h2 class="mb-4">Verbal Autopsy Actions</h2>
-      {% if is_production %}
-        <form method="post" action="{% url 'data_management:run_coding_algorithms' %}">
-          {% csrf_token %}
-          <button class="btn btn-primary" type="submit">
-            <i class="fas fa-file-prescription"></i>
-            &nbsp;Run Coding Algorithms
-          </button>
-        </form>
-      {% else %}
-        <button class="btn btn-primary" disabled title="Only available in production">
+      <form method="post" action="{% url 'data_management:run_coding_algorithms' %}">
+        {% csrf_token %}
+        <button class="btn btn-primary" type="submit">
           <i class="fas fa-file-prescription"></i>
           &nbsp;Run Coding Algorithms
         </button>
-      {% endif %}
+      </form>
   </div>
 </div>
 {% endif %}

--- a/va_explorer/va_data_management/tasks.py
+++ b/va_explorer/va_data_management/tasks.py
@@ -1,13 +1,95 @@
+from celery.schedules import crontab
+
 from config.celery_app import app
-from va_explorer.va_data_management.utils import coding
+from config.settings.base import env
+from va_explorer.va_data_management.management.commands.import_from_kobo import (
+    BATCH_SIZE,
+)
+from va_explorer.va_data_management.utils import coding, kobo, odk
+from va_explorer.va_data_management.utils.loading import load_records_from_dataframe
 
 
+@app.on_after_finalize.connect
+def setup_periodic_tasks(sender, **kwargs):
+    # Import from Kobo daily at 00:00
+    sender.add_periodic_task(
+        crontab(hour=0, minute=0), import_from_kobo.s(), name="Import from Kobo daily"
+    )
+
+    # Run Coding Algorithms daily at 00:30
+    sender.add_periodic_task(
+        crontab(hour=0, minute=30),
+        run_coding_algorithms.s(),
+        name="Run Coding Algorithms daily",
+    )
+
+
+# Result of tasks need to be json serializable so return dicts.
 @app.task()
 def run_coding_algorithms():
     results = coding.run_coding_algorithms()
-    # Result of task needs to be json serializable so just make a JSON list.
     return {
         "num_coded": len(results["causes"]),
         "num_total": len(results["verbal_autopsies"]),
         "num_issues": len(results["issues"]),
+    }
+
+
+@app.task()
+def import_from_odk():
+    options = {
+        "email": env("ODK_EMAIL"),
+        "password": env("ODK_PASSWORD"),
+        "project_id": env("ODK_PROJECT_ID"),
+        "form_id": env("ODK_FORM_ID"),
+    }
+    data = odk.download_responses(
+        options["email"],
+        options["password"],
+        project_id=options["project_id"],
+        form_id=options["form_id"],
+    )
+    results = load_records_from_dataframe(data)
+    return {
+        "num_created": len(results["created"]),
+        "num_ignored": len(results["ignored"]),
+        "num_outdated": len(results["outdated"]),
+    }
+
+
+@app.task()
+def import_from_kobo():
+    options = {
+        "token": env("KOBO_API_TOKEN"),
+        "asset_id": env("KOBO_ASSET_ID"),
+    }
+    data, next_page = kobo.download_responses(
+        options["token"], options["asset_id"], BATCH_SIZE, None
+    )
+    results = load_records_from_dataframe(data)
+
+    num_created = len(results["created"])
+    num_ignored = len(results["ignored"])
+    num_outdated = len(results["outdated"])
+    num_corrected = len(results["corrected"])
+    num_invalid = len(results["removed"])
+
+    # Process all available pages of kobo data since it is provided via pagination
+    while next_page is not None:
+        data, next_page = kobo.download_responses(
+            options["token"], options["asset_id"], BATCH_SIZE, next_page
+        )
+        results = load_records_from_dataframe(data)
+        num_created = num_created + len(results["created"])
+        num_ignored = num_ignored + len(results["ignored"])
+        num_outdated = num_outdated + len(results["outdated"])
+        num_corrected = num_corrected + len(results["corrected"])
+        num_invalid = num_invalid + len(results["removed"])
+
+    return {
+        "num_ignored": num_ignored,
+        "num_outdated": num_outdated,
+        "num_created": num_created,
+        "num_corrected": num_corrected,
+        "num_removed": num_invalid,
     }

--- a/va_explorer/va_data_management/utils/loading.py
+++ b/va_explorer/va_data_management/utils/loading.py
@@ -23,7 +23,7 @@ User = get_user_model()
 
 
 # load VA records into django database
-def load_records_from_dataframe(record_df, random_locations=False, debug=True):
+def load_records_from_dataframe(record_df, random_locations=False, debug=False):
     logger = None if not debug else logging.getLogger("debug")
     if logger:
         header = "=" * 10 + "DATA INGEST" + "=" * 10
@@ -134,7 +134,8 @@ def load_records_from_dataframe(record_df, random_locations=False, debug=True):
 
     # build location mapper to map csv locations to known db locations
     if "hospital" in record_df.columns:
-        location_map = build_location_mapper(record_df["hospital"].unique().tolist())
+        hospitals = record_df["hospital"].unique().tolist()
+        location_map = build_location_mapper(hospitals)
 
     # if random locations, assign random locations via a random field worker.
     if random_locations:

--- a/va_explorer/va_data_management/utils/location_assignment.py
+++ b/va_explorer/va_data_management/utils/location_assignment.py
@@ -16,14 +16,22 @@ def build_location_mapper(
 ):
     if va_locations and len(va_locations) > 0:
         # store database locations of type location_type in a df
-        if not db_locations:
-            db_locations = list(
-                Location.objects.filter(location_type=loc_type).values_list(
-                    "name", flat=True
+        try:
+            if not db_locations:
+                db_locations = list(
+                    Location.objects.filter(location_type=loc_type).values_list(
+                        "name", flat=True
+                    )
                 )
-            )
+            if len(db_locations) == 0:
+                raise RuntimeWarning(
+                    "No known facilities found. Have you initialized location data?"
+                )
+        except RuntimeWarning as warn:
+            print("%s", warn)
+
         location_df = pd.DataFrame({"name": db_locations}).assign(
-            key=lambda df: df["name"].str.lower()
+            key=lambda df: df["name"].astype(str).str.lower()
         )
 
         # store unique va_locations in mapper dataframe


### PR DESCRIPTION
This PR utilizes existing celery, celery beat, and flower functionality to:

- Add a scheduled task to import from kobo daily at 00:00
- Add a scheduled task to run coding algorithms daily at 00:30
- Opens port 5555 of the flower container to access tasks UI
- Adds basic auth for accessing the flower UI

Also adds
- Adds a task to run import from odk (but does not schedule it to run)
- Adds a new warning to `location_assignment.py` regarding absence of hospitals in the db to make a failure condition more obvious

Testing suggestions:

> Add `CELERY_FLOWER_USER` and `CELERY_FLOWER_PASSWORD` to your .env file and set their values with something appropriate.

1. run `docker compose up -d --build` to create the containers; optionally observe them with `docker compose logs -f`

> If this is a fresh db, you may need to run `docker cp zambia_locations.csv va_explorer-django-1:/app/zambia_locations.csv` 

2. in another terminal run `docker exec -it va_explorer-django-1 bash` to get into the django container

> If you are initializing locations run `./manage.py load_locations zambia_locations.csv` now

3. Run `./manage.py shell` with the following commands. You can use `apply()` as listed below to have it run immediately and see the logs from the command or use `apply_async()` instead to have it show up in flower. 

```
from va_explorer.va_data_management.tasks import import_from_kobo
import_from_kobo.apply()
```

You should be able to navigate to flower via `localhost:5555` and va_explorer via `localhost:5000`

> If this is a fresh db, you may need to run `./manage.py seed_admin_user <EMAIL> --password <PASSWORD>` from inside the container to login and see the practical results of import_from_kobo and run_coding_algorithms. You should also be able to press the `Run Coding Algorithms` button on the homepage and have a job start on-demand.