### PR TITLE
apply locations update hotfix

### DIFF
--- a/va_explorer/templates/va_data_management/show.html
+++ b/va_explorer/templates/va_data_management/show.html
@@ -146,7 +146,7 @@
             {% for diff in diffs %}
               <tr>
                 <td>{{ diff.new_record.history_date|date:"Y-m-d H:i" }}</td>
-                <td>{{ diff.new_record.history_user.name }} &lt;{{ diff.new_record.history_user.email }}&gt;</td>
+                <td>{{ diff.new_record.history_user.name|default:"System" }} &lt;{{ diff.new_record.history_user.email|default:"noreply@host" }}&gt;</td>
                 <td>
                   {% for change in diff.changes %}
                     {% if change.old and change.new %}

--- a/va_explorer/users/forms.py
+++ b/va_explorer/users/forms.py
@@ -8,6 +8,7 @@ from django import forms
 from django.contrib.auth import get_user_model, password_validation
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import Group
+from django.db.models import Q
 from django.forms import (
     ModelChoiceField,
     ModelMultipleChoiceField,
@@ -134,7 +135,9 @@ class UserCommonFields(forms.ModelForm):
     )
     location_restrictions = ModelMultipleChoiceField(
         # Don't include 'Unknown' or Root/Country node in options
-        queryset=Location.objects.all().order_by("path")[2:],
+        queryset=Location.objects.all()
+        .exclude(Q(location_type="country") | Q(name="Unknown"))
+        .order_by("path"),
         widget=LocationRestrictionsSelectMultiple(
             attrs={"class": "location-restrictions-select"}
         ),

--- a/va_explorer/users/forms.py
+++ b/va_explorer/users/forms.py
@@ -95,7 +95,8 @@ class LocationRestrictionsSelectMultiple(SelectMultiple):
             name, value, label, selected, index, subindex, attrs
         )
         if value:
-            option["attrs"]["data-depth"] = value.instance.depth
+            # Use depth - 1 to account for root/country node
+            option["attrs"]["data-depth"] = value.instance.depth - 1
             # Only query for descendants if there are any
             if value.instance.numchild > 0:
                 option["attrs"][
@@ -132,7 +133,8 @@ class UserCommonFields(forms.ModelForm):
         queryset=Group.objects.all(), required=True, widget=GroupSelect
     )
     location_restrictions = ModelMultipleChoiceField(
-        queryset=Location.objects.all().order_by("path"),
+        # Don't include 'Unknown' or Root/Country node in options
+        queryset=Location.objects.all().order_by("path")[2:],
         widget=LocationRestrictionsSelectMultiple(
             attrs={"class": "location-restrictions-select"}
         ),

--- a/va_explorer/va_data_management/management/commands/refresh_locations.py
+++ b/va_explorer/va_data_management/management/commands/refresh_locations.py
@@ -1,3 +1,5 @@
+from math import ceil
+
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
@@ -10,38 +12,46 @@ class Command(BaseCommand):
     help = "Reassigns locations based on most recent facility list"
 
     def handle(self, *args, **options):
-        if settings.DEBUG:
-            count = VerbalAutopsy.objects.count()
-            print(
-                "Refreshing locations for all " + str(count) + " VAs in the database."
-            )
+        count = VerbalAutopsy.objects.count()
+        print(f"Refreshing locations for all {count} VAs in the database.")
 
-        # build location mapper to map csv locations to known db locations
-        # using list comprehension to remove duplicated from list
-        location_map = {}
-        verbal_autopsies = list(VerbalAutopsy.objects.all())
-        h = [va.hospital for va in verbal_autopsies]
-        hospitals = []
-        [hospitals.append(x) for x in h if x not in hospitals]
-
-        location_map = {
-            key_name_pair[0]: key_name_pair[1]
-            for key_name_pair in Location.objects.filter(key__in=hospitals)
-            .only("name", "key")
-            .values_list("key", "name")
-        }
-
+        # Update in batches so we don't overwhelm RAM
+        batch_size = 5000
+        batches = ceil(count / batch_size)
         changed_count = 0
-        for va in verbal_autopsies:
-            old_location = va.location
-            new_va = assign_va_location(va, location_map)
-            new_location = new_va.location
 
-            if old_location != new_location:
-                changed_count += 1
-                va.location = new_va.location
-                va.save_without_historical_record()
+        for i in range(batches):
+            if settings.DEBUG:
+                print(f"  refresh_locations batch {i} out of {batches}")
 
-        validate_vas_for_dashboard(verbal_autopsies)
+            batch_start = i * batch_size
+            batch_end = (i + 1) * batch_size
 
-        print("   changed locations for " + str(changed_count) + " VA(s).")
+            # build location mapper to map csv locations to known db locations
+            # using list comprehension to remove duplicated from list
+            location_map = {}
+            verbal_autopsies = list(VerbalAutopsy.objects.all()[batch_start:batch_end])
+            h = [va.hospital for va in verbal_autopsies]
+            hospitals = []
+            [hospitals.append(x) for x in h if x not in hospitals]
+
+            location_map = {
+                key_name_pair[0]: key_name_pair[1]
+                for key_name_pair in Location.objects.filter(key__in=hospitals)
+                .only("name", "key")
+                .values_list("key", "name")
+            }
+
+            for va in verbal_autopsies:
+                old_location = va.location
+                new_va = assign_va_location(va, location_map)
+                new_location = new_va.location
+
+                if old_location != new_location:
+                    changed_count += 1
+                    va.location = new_va.location
+                    va.save()
+
+            validate_vas_for_dashboard(verbal_autopsies)
+
+        print(f"Done: changed locations for {changed_count} VA(s).")

--- a/va_explorer/va_export/forms.py
+++ b/va_explorer/va_export/forms.py
@@ -44,7 +44,8 @@ class VADownloadForm(forms.Form):
     )
 
     locations = ModelMultipleChoiceField(
-        queryset=Location.objects.all().order_by("path"),
+        # Don't include 'Unknown' or Root/Country node in options
+        queryset=Location.objects.all().order_by("path")[2:],
         widget=LocationRestrictionsSelectMultiple(
             attrs={"class": "location-restrictions-select"}
         ),

--- a/va_explorer/va_export/forms.py
+++ b/va_explorer/va_export/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.db.models import Q
 from django.forms import DateField, ModelMultipleChoiceField, Select, SelectMultiple
 
 from va_explorer.users.forms import LocationRestrictionsSelectMultiple
@@ -45,7 +46,9 @@ class VADownloadForm(forms.Form):
 
     locations = ModelMultipleChoiceField(
         # Don't include 'Unknown' or Root/Country node in options
-        queryset=Location.objects.all().order_by("path")[2:],
+        queryset=Location.objects.all()
+        .exclude(Q(location_type="country") | Q(name="Unknown"))
+        .order_by("path"),
         widget=LocationRestrictionsSelectMultiple(
             attrs={"class": "location-restrictions-select"}
         ),


### PR DESCRIPTION
1. batch refresh_locations - non-batched approach was prone to using too much RAM if # of VAs to refresh is large enough. break up operation into batches of 5000
2. reduce depth for select2 - account for unknown and root node taking up space in select2 dropdown by removing those values and reducing depth of other tree values in select2 widget used for location selection
3. display location names in diffs - to show something more informative to the user like location name -> name instead of location pk -> pk