### PR TITLE
Version bump python, requirements.txt packages, and docker images

### DIFF
--- a/.github/workflows/django-ci-test.yml
+++ b/.github/workflows/django-ci-test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/django-ci-test.yml
+++ b/.github/workflows/django-ci-test.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.2
+        image: postgres:17.5
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/pages_documentation.yml
+++ b/.github/workflows/pages_documentation.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4          # Get code
-      - uses: actions/setup-python@v4       # Get Python for dependencies
+      - uses: actions/setup-python@v5       # Get Python for dependencies
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.11.12
+  rev: v0.12.0
   hooks:
     - id: ruff-check
 - repo: https://github.com/psf/black-pre-commit-mirror

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.12.0
+  rev: v0.12.1
   hooks:
     - id: ruff-check
 - repo: https://github.com/psf/black-pre-commit-mirror

--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -59,7 +59,7 @@ COPY --chown=django:django .env /app/.env
 COPY --chown=django:django config /app/config
 COPY --chown=django:django va_explorer /app/va_explorer
 
-RUN python /app/manage.py collectstatic --noinput
+RUN python /app/manage.py collectstatic --noinput --settings=config.settings.production
 
 USER django
 

--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -59,6 +59,8 @@ COPY --chown=django:django .env /app/.env
 COPY --chown=django:django config /app/config
 COPY --chown=django:django va_explorer /app/va_explorer
 
+RUN python /app/manage.py collectstatic --noinput
+
 USER django
 
 ENTRYPOINT ["/entrypoint"]

--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -1,48 +1,64 @@
 
-FROM python:3.8-slim-buster
+FROM python:3.12-slim-bookworm AS python
 
-ENV PYTHONUNBUFFERED 1
+FROM python AS python-build-stage
 
-RUN apt-get update \
+RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
-  && apt-get install -y build-essential \
-  # psycopg2 dependencies
-  && apt-get install -y libpq-dev \
-  # Translations dependencies
-  && apt-get install -y gettext \
-  # cleaning up unused files
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN addgroup --system django && adduser --system --ingroup django django
+  build-essential \
+  # psycopg dependencies
+  libpq-dev
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements
-RUN pip install --no-cache-dir -r /requirements/production.txt
+# Create Python Dependency and Sub-Dependency Wheels
+RUN pip wheel --wheel-dir /usr/src/app/wheels \
+  -r ./requirements/production.txt
+
+FROM python AS python-run-stage
+
+ARG APP_HOME=/app
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+WORKDIR ${APP_HOME}
+
+RUN addgroup --system django \
+  && adduser --system --ingroup django django
+
+# Install required system dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  libpq-dev \
+  gettext \
+  wait-for-it \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/*
+
+# All absolute dir copies ignore workdir instruction. All relative dir copies
+# are wrt to the workdir instruction. copy python dependency wheels from python-build-stage
+COPY --from=python-build-stage /usr/src/app/wheels /wheels/
+
+# use wheels to install python dependencies
+RUN pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \
+  && rm -rf /wheels/
+
 
 # Copy all commands.
-COPY ./compose/django/entrypoint /entrypoint
-COPY ./compose/django/start /start
-COPY ./compose/django/celery/worker/start /start-celeryworker
-COPY ./compose/django/celery/beat/start /start-celerybeat
-COPY ./compose/django/celery/flower/start /start-celeryflower
+COPY --chown=django:django ./compose/django/entrypoint /entrypoint
+COPY --chown=django:django ./compose/django/start /start
+COPY --chown=django:django ./compose/django/celery/worker/start /start-celeryworker
+COPY --chown=django:django ./compose/django/celery/beat/start /start-celerybeat
+COPY --chown=django:django ./compose/django/celery/flower/start /start-celeryflower
 
 RUN chmod +x /entrypoint /start /start-celeryworker /start-celerybeat /start-celeryflower
-RUN chown django /entrypoint /start /start-celeryworker /start-celerybeat /start-celeryflower
 RUN sed -i 's/\r$//g' /entrypoint /start /start-celeryworker /start-celerybeat /start-celeryflower
 
-RUN mkdir /app && chown django /app
+# copy application code to WORKDIR
+COPY --chown=django:django manage.py /app/manage.py
+COPY --chown=django:django locale /app/locale
+COPY --chown=django:django .env /app/.env
+COPY --chown=django:django config /app/config
+COPY --chown=django:django va_explorer /app/va_explorer
 
 USER django
-
-COPY --chown=django:django .env /app/.env
-COPY --chown=django:django manage.py /app/manage.py
-COPY --chown=django:django va_explorer /app/va_explorer
-COPY --chown=django:django config /app/config
-COPY --chown=django:django locale /app/locale
-
-RUN python /app/manage.py collectstatic --settings=config.settings.production
-
-WORKDIR /app
 
 ENTRYPOINT ["/entrypoint"]

--- a/compose/django/entrypoint
+++ b/compose/django/entrypoint
@@ -9,30 +9,8 @@ if [ -z "${POSTGRES_USER}" ]; then
 fi
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
-postgres_ready() {
-python << END
-import sys
+wait-for-it "${POSTGRES_HOST}:${POSTGRES_PORT}" -t 30
 
-import psycopg2
-
-try:
-    psycopg2.connect(
-        dbname="${POSTGRES_DB}",
-        user="${POSTGRES_USER}",
-        password="${POSTGRES_PASSWORD}",
-        host="${POSTGRES_HOST}",
-        port="${POSTGRES_PORT}",
-    )
-except psycopg2.OperationalError:
-    sys.exit(-1)
-sys.exit(0)
-
-END
-}
-until postgres_ready; do
-  >&2 echo 'Waiting for PostgreSQL to become available...'
-  sleep 1
-done
 >&2 echo 'PostgreSQL is available'
 
 exec "$@"

--- a/compose/django/start
+++ b/compose/django/start
@@ -6,9 +6,6 @@ set -o nounset
 
 export DJANGO_SETTINGS_MODULE=config.settings.production
 
-echo "Collecting static assets..."
-RUN python /app/manage.py collectstatic --noinput
-
 echo "Running database migrations..."
 python /app/manage.py migrate
 

--- a/compose/django/start
+++ b/compose/django/start
@@ -6,6 +6,9 @@ set -o nounset
 
 export DJANGO_SETTINGS_MODULE=config.settings.production
 
+echo "Collecting static assets..."
+RUN python /app/manage.py collectstatic --noinput
+
 echo "Running database migrations..."
 python /app/manage.py migrate
 

--- a/compose/postgres/Dockerfile
+++ b/compose/postgres/Dockerfile
@@ -1,5 +1,6 @@
-FROM postgres:13.2
+FROM postgres:17.5
 
 COPY ./compose/postgres/maintenance /usr/local/bin/maintenance
 RUN chmod +x /usr/local/bin/maintenance/*
-RUN mv /usr/local/bin/maintenance/* /usr/local/bin && rmdir /usr/local/bin/maintenance
+RUN mv /usr/local/bin/maintenance/* /usr/local/bin \
+    && rmdir /usr/local/bin/maintenance

--- a/compose/postgres/maintenance/backup
+++ b/compose/postgres/maintenance/backup
@@ -4,7 +4,7 @@
 ### Create a database backup.
 ###
 ### Usage:
-###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres backup
+###     $ docker compose -f <environment>.yml (exec |run --rm) postgres backup
 
 
 set -o errexit

--- a/compose/postgres/maintenance/backups
+++ b/compose/postgres/maintenance/backups
@@ -4,7 +4,7 @@
 ### View backups.
 ###
 ### Usage:
-###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres backups
+###     $ docker compose -f <environment>.yml (exec |run --rm) postgres backups
 
 
 set -o errexit

--- a/compose/postgres/maintenance/restore
+++ b/compose/postgres/maintenance/restore
@@ -7,7 +7,7 @@
 ###     <1> filename of an existing backup.
 ###
 ### Usage:
-###     $ docker-compose -f <environment>.yml (exec |run --rm) postgres restore <1>
+###     $ docker compose -f <environment>.yml (exec |run --rm) postgres restore <1>
 
 
 set -o errexit

--- a/compose/postgres/maintenance/rmbackup
+++ b/compose/postgres/maintenance/rmbackup
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+### Remove a database backup.
+###
+### Parameters:
+###     <1> filename of a backup to remove.
+###
+### Usage:
+###     $ docker compose -f <environment>.yml (exec |run --rm) postgres rmbackup <1>
+
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+working_dir="$(dirname ${0})"
+source "${working_dir}/_sourced/constants.sh"
+source "${working_dir}/_sourced/messages.sh"
+
+
+if [[ -z ${1+x} ]]; then
+    message_error "Backup filename is not specified yet it is a required parameter. Make sure you provide one and try again."
+    exit 1
+fi
+backup_filename="${BACKUP_DIR_PATH}/${1}"
+if [[ ! -f "${backup_filename}" ]]; then
+    message_error "No backup with the specified filename found. Check out the 'backups' maintenance script output to see if there is one and try again."
+    exit 1
+fi
+
+message_welcome "Removing the '${backup_filename}' backup file..."
+
+rm -r "${backup_filename}"
+
+message_success "The '${backup_filename}' database backup has been removed."

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,6 +3,7 @@ Base settings to build other settings files upon.
 """
 
 import os
+import ssl
 from pathlib import Path
 
 import environ
@@ -219,6 +220,7 @@ TEMPLATES = [
 
 FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 CRISPY_TEMPLATE_PACK = "bootstrap4"
+CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap4"
 
 FIXTURE_DIRS = (str(APPS_DIR / "fixtures"),)
 
@@ -279,11 +281,17 @@ CACHES = {
     }
 }
 
+REDIS_URL = env("REDIS_URL", default="redis://redis:6379/0")
+REDIS_SSL = REDIS_URL.startswith("rediss://")
+
+
 # Celery
 if USE_TZ:
     CELERY_TIMEZONE = TIME_ZONE
-CELERY_BROKER_URL = env("CELERY_BROKER_URL", default="redis://redis:6379/0")
+CELERY_BROKER_URL = env("CELERY_BROKER_URL", default=REDIS_URL)
+CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE} if REDIS_SSL else None
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+CELERY_REDIS_BACKEND_USE_SSL = CELERY_BROKER_USE_SSL
 CELERY_RESULT_EXTENDED = True
 CELERY_RESULT_BACKEND_ALWAYS_RETRY = True
 CELERY_RESULT_BACKEND_MAX_RETRIES = 5
@@ -300,6 +308,7 @@ CELERY_TASK_SOFT_TIME_LIMIT = 2700
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_WORKER_SEND_TASK_EVENTS = True
 CELERY_TASK_SEND_SENT_EVENT = True
+CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 
 # Allauth
 ACCOUNT_ALLOW_REGISTRATION = env.bool("DJANGO_ACCOUNT_ALLOW_REGISTRATION", False)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -84,6 +84,7 @@ DJANGO_APPS = [
 THIRD_PARTY_APPS = [
     "rest_framework",
     "crispy_forms",
+    "crispy_bootstrap4",
     "allauth",
     "allauth.account",
     "django_celery_beat",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -154,6 +154,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.common.BrokenLinkEmailsMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
     # Track which user makes VA data edits
     "simple_history.middleware.HistoryRequestMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
@@ -301,10 +302,9 @@ CELERY_TASK_SEND_SENT_EVENT = True
 
 # Allauth
 ACCOUNT_ALLOW_REGISTRATION = env.bool("DJANGO_ACCOUNT_ALLOW_REGISTRATION", False)
-ACCOUNT_AUTHENTICATION_METHOD = "email"
-ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_LOGIN_METHODS = {"email"}
+ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 ACCOUNT_EMAIL_VERIFICATION = "none"
 ACCOUNT_ADAPTER = "va_explorer.users.adapters.AccountAdapter"
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
-ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_USER_DISPLAY = lambda user: user.name  # noqa: E731 - allow this limited use

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
-version: '3'
-
 volumes:
   production_postgres_data: {}
   production_postgres_data_backups: {}
-  
+  production_redis_data: {}
+
 services:
   pycrossva:
     image: va_explorer/pycrossva
@@ -18,7 +17,9 @@ services:
       - "5002:5002"
 
   redis:
-    image: redis:5.0
+    image: redis:8.0.2
+    volumes:
+      - production_redis_data:/data
 
   django: &django
     image: va_explorer/django
@@ -49,24 +50,25 @@ services:
 
   celeryworker:
     <<: *django
-    # Don't publish ports like django does.
-    ports: []
     image: va_explorer/celeryworker
+    depends_on:
+      - redis
+    ports: []
     command: /start-celeryworker
 
   celerybeat:
     <<: *django
-    # Don't publish ports like django does.
-    ports: []
     image: va_explorer/celerybeat
+    depends_on:
+      - redis
+    ports: []
     command: /start-celerybeat
 
   flower:
     <<: *django
-    # Don't publish ports like django does.
+    image: va_explorer/flower
     ports:
       - "5555:5555"
-    image: va_explorer/flower
     command: /start-celeryflower
 
   vapostgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - production_postgres_data_backups:/backups
 
   redis:
-    image: redis:8.0.2
+    image: redis:8
     container_name: va_explorer_redis
     volumes:
       - production_redis_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,31 +4,29 @@ volumes:
   production_redis_data: {}
 
 services:
+  # Support builds on Apple silicon via platform config
   pycrossva:
-    image: va_explorer/pycrossva
     build: https://github.com/VA-Explorer/pyCrossVA.git#microservice-experiment
+    platform: linux/x86_64
+    container_name: va_explorer_pycrossva
     ports:
       - "5001:80"
     
   interva5:
-    image: va_explorer/interva5
     build: https://github.com/VA-Explorer/InterVA5.git#microservice-experiment
+    platform: linux/x86_64
+    container_name: va_explorer_interva5
     ports:
       - "5002:5002"
 
-  redis:
-    image: redis:8.0.2
-    volumes:
-      - production_redis_data:/data
-
   django: &django
-    image: va_explorer/django
     build:
       context: .
       dockerfile: ./compose/django/Dockerfile
-    ports:
-      - "5000:5000"
+    platform: linux/x86_64
+    container_name: va_explorer_django
     depends_on:
+      - postgres
       - redis
     environment:
       EMAIL_URL: ${EMAIL_URL:-smtp://localhost:25}
@@ -46,36 +44,15 @@ services:
       DJANGO_DEFAULT_FROM_EMAIL: ${DJANGO_DEFAULT_FROM_EMAIL:-VA Explorer <noreply@vaexplorer.org>} 
       PYCROSS_HOST: ${PYCROSS_HOST:-http://pycrossva:80}
       INTERVA_HOST: ${INTERVA_HOST:-http://interva5:5002}
+    ports:
+      - "5000:5000"
     command: /start
 
-  celeryworker:
-    <<: *django
-    image: va_explorer/celeryworker
-    depends_on:
-      - redis
-    ports: []
-    command: /start-celeryworker
-
-  celerybeat:
-    <<: *django
-    image: va_explorer/celerybeat
-    depends_on:
-      - redis
-    ports: []
-    command: /start-celerybeat
-
-  flower:
-    <<: *django
-    image: va_explorer/flower
-    ports:
-      - "5555:5555"
-    command: /start-celeryflower
-
-  vapostgres:
-    image: va_explorer/postgres
+  postgres:
     build:
       context: .
       dockerfile: ./compose/postgres/Dockerfile
+    container_name: va_explorer_postgres
     environment:
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}
@@ -85,3 +62,33 @@ services:
     volumes:
       - production_postgres_data:/var/lib/postgresql/data
       - production_postgres_data_backups:/backups
+
+  redis:
+    image: redis:8.0.2
+    container_name: va_explorer_redis
+    volumes:
+      - production_redis_data:/data
+
+  celeryworker:
+    <<: *django
+    container_name: va_explorer_celeryworker
+    depends_on:
+      - redis
+    ports: []
+    command: /start-celeryworker
+
+  celerybeat:
+    <<: *django
+    container_name: va_explorer_celerybeat
+    depends_on:
+      - redis
+    ports: []
+    command: /start-celerybeat
+
+  flower:
+    <<: *django
+    container_name: va_explorer_flower
+    ports:
+      - "5555:5555"
+    command: /start-celeryflower
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     platform: linux/x86_64
     container_name: va_explorer_django
     depends_on:
-      - postgres
+      - vapostgres
       - redis
     environment:
       EMAIL_URL: ${EMAIL_URL:-smtp://localhost:25}
@@ -48,7 +48,7 @@ services:
       - "5000:5000"
     command: /start
 
-  postgres:
+  vapostgres:
     build:
       context: .
       dockerfile: ./compose/postgres/Dockerfile

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,9 +25,9 @@ copyright = "2020-2025, MITRE Licensed under Apache 2.0"
 author = "MITRE <verbal-autopsy@mitre.org>"
 
 # The short X.Y version
-version = "1.2"
+version = "0.2"
 # The full version, including alpha/beta/rc tags
-release = "1.2.0"
+release = "0.2.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,13 +21,13 @@ sys.path.insert(0, project_root)
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "VA Explorer Docs"
-copyright = "2020-2023, MITRE Licensed under Apache 2.0"
-author = "MITRE"
+copyright = "2020-2025, MITRE Licensed under Apache 2.0"
+author = "MITRE <verbal-autopsy@mitre.org>"
 
 # The short X.Y version
-version = "1.0"
+version = "1.2"
 # The full version, including alpha/beta/rc tags
-release = "1.0.1"
+release = "1.2.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/usage/getting_started/tips.md
+++ b/docs/usage/getting_started/tips.md
@@ -22,7 +22,7 @@ Once this process has finished, `EMAIL_URL` can similarly be customized to point
 to `localhost`.
 
 ```{note}
-If users are reporting non-receipt of emails, the [Frequently Asked Questions](training/troubleshooting.md#frequently-asked-questions)
+If users are reporting non-receipt of emails, the [Frequently Asked Questions](../../training/troubleshooting.md#frequently-asked-questions)
 section may help.
 ```
 

--- a/docs/usage/integrations.md
+++ b/docs/usage/integrations.md
@@ -28,7 +28,7 @@ connect it to the necessary containers like so:
 ```sh
 docker network create <external network name>
 docker network connect <external network name> va_explorer_django_1
-docker network connect <external network name> <other service's container name>
+docker network connect <external network name> <other service container names>
 ```
 
 VA Explorer provides some additional network configuration to enable use of this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ authors = [{ name = "MITRE", email = "verbal-autopsy@mitre.org" }]
 maintainers = [{ name = "MITRE", email = "verbal-autopsy@mitre.org" }]
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
-keywords = ["verbal autopsy", "cause of death", "global health", "interva", "django"]
+keywords = ["verbal autopsy", "cause of death", "global health", "interva", "django", "mortality surveillance"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Handhelds/PDA's",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Healthcare Industry",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
@@ -80,27 +80,3 @@ plugins = ["django_coverage_plugin"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
-
-# [tool.mypy]
-# python_version = "3.10"
-# plugins = ["mypy_django_plugin.main"]
-# settings from https://quantlane.com/blog/type-checking-large-codebase/
-# check_untyped_defs = true
-# disallow_any_generics = true
-# disallow_incomplete_defs = true
-# disallow_subclassing_any = true
-# disallow_untyped_calls = false
-# disallow_untyped_decorators = false
-# disallow_untyped_defs = true
-# follow_imports = "silent"
-# ignore_missing_imports = true
-# no_implicit_optional = true
-# show_error_codes = true
-# warn_redundant_casts = true
-# warn_return_any = true
-# warn_unreachable = true
-# warn_unused_configs = true
-# warn_unused_ignores = true
-
-# [tool.django-stubs]
-# django_settings_module = "config.settings.test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "va-explorer"
-version = "0.1.0"
+version = "0.2.0"
 description = "A full service VA management prototype webapp"
 authors = [{ name = "MITRE", email = "verbal-autopsy@mitre.org" }]
 maintainers = [{ name = "MITRE", email = "verbal-autopsy@mitre.org" }]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 license = { file = "LICENSE" }
 keywords = ["verbal autopsy", "cause of death", "global health", "interva", "django"]
 classifiers = [
@@ -12,15 +12,15 @@ classifiers = [
     "Environment :: Handhelds/PDA's",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.1",
+    "Framework :: Django :: 5.1",
     "Intended Audience :: Healthcare Industry",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: Unix",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
     "Topic :: Scientific/Engineering :: GIS",
@@ -54,7 +54,7 @@ extend-exclude = ["migrations"]
 
 [tool.black]
 line-length = 88
-target-version = ['py310']
+target-version = ['py312']
 # Use force-exclude option due to way pre-commit parses files. See psf/black#438
 force-exclude = '''
 /(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ anytree==2.12.1
 numpy<2
 
 # Django
-django==4.1.2
+django==4.2.23
 django-environ==0.9.0
 django-extensions==3.2.1
 werkzeug==2.2.2 # required by django-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,15 +3,15 @@ argon2-cffi==25.1.0
 python-slugify==8.0.4
 pytz==2025.2
 requests==2.32.4
-pandas==1.5.1   #TODO:
+pandas==2.3.0
 fuzzywuzzy==0.18.0
 python-Levenshtein==0.27.1
 tqdm==4.67.1
 anytree==2.13.0
-numpy<2   # TODO:
+numpy==2.3.1
 
 # Django
-django==5.1.0
+django==5.2.3
 django-environ==0.12.0
 django-extensions==4.1
 werkzeug==3.1.3 # required by django-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ django-extensions==3.2.1
 werkzeug==2.2.2 # required by django-extensions
 whitenoise==6.2.0
 django-debug-toolbar==3.7.0
-django-allauth==0.52.0
+django-allauth==65.9.0
 django-bootstrap4==22.2
 django-crispy-forms==1.14.0
 django-simple-history==3.1.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # General/ Utility
 argon2-cffi==21.3.0
 python-slugify==6.1.2
-pytz==2022.5
+pytz==2025.2
 requests==2.28.1
 pandas==1.5.1
 fuzzywuzzy==0.18.0
@@ -17,15 +17,15 @@ django-extensions==3.2.1
 werkzeug==2.2.2 # required by django-extensions
 whitenoise==6.2.0
 django-debug-toolbar==3.7.0
-django-allauth==0.51.0
+django-allauth==0.52.0
 django-bootstrap4==22.2
 django-crispy-forms==1.14.0
 django-simple-history==3.1.1
 django-treebeard==4.7
-django-celery-beat==2.4.0
+django-celery-beat==2.8.1
 django-redis==5.2.0
 django-filter==22.1
-django-pivot==1.9.0
+django-pivot==1.10.0
 djangorestframework==3.14.0
 django-cors-headers==3.13.0
 
@@ -34,7 +34,7 @@ amqp==5.1.1
 celery==5.2.7
 redis==4.3.4
 hiredis==2.0.0
-flower==1.2.0
+flower==2.0.1
 
 # Database
 psycopg2==2.9.5 --no-binary psycopg2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,40 +1,41 @@
 # General/ Utility
-argon2-cffi==21.3.0
-python-slugify==6.1.2
+argon2-cffi==25.1.0
+python-slugify==8.0.4
 pytz==2025.2
-requests==2.28.1
-pandas==1.5.1
+requests==2.32.4
+pandas==1.5.1   #TODO:
 fuzzywuzzy==0.18.0
-python-Levenshtein==0.20.7
-tqdm==4.65.0
-anytree==2.12.1
-numpy<2
+python-Levenshtein==0.27.1
+tqdm==4.67.1
+anytree==2.13.0
+numpy<2   # TODO:
 
 # Django
-django==5.0.0
-django-environ==0.9.0
-django-extensions==3.2.1
-werkzeug==2.2.2 # required by django-extensions
-whitenoise==6.2.0
-django-debug-toolbar==3.7.0
+django==5.1.0
+django-environ==0.12.0
+django-extensions==4.1
+werkzeug==3.1.3 # required by django-extensions
+whitenoise==6.9.0
+django-debug-toolbar==5.2.0
 django-allauth==65.9.0
-django-bootstrap4==22.2
-django-crispy-forms==1.14.0
-django-simple-history==3.1.1
-django-treebeard==4.7
+django-bootstrap4==25.1
+django-crispy-forms==2.4
+crispy-bootstrap4==2025.6
+django-simple-history==3.10.1
+django-treebeard==4.7.1
 django-celery-beat==2.8.1
-django-redis==5.2.0
-django-filter==22.1
+django-redis==6.0.0   #TODO:
+django-filter==25.1
 django-pivot==1.10.0
-djangorestframework==3.14.0
-django-cors-headers==3.13.0
+djangorestframework==3.16.0
+django-cors-headers==4.7.0
 
 # Celery/ Redis
-amqp==5.1.1
-celery==5.2.7
-redis==4.3.4
-hiredis==2.0.0
+amqp==5.3.1
+celery==5.5.3
+redis==4.3.4    #TODO:
+hiredis==2.0.0  #TODO:
 flower==2.0.1
 
 # Database
-psycopg2==2.9.5 --no-binary psycopg2
+psycopg[c]==3.2.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ anytree==2.12.1
 numpy<2
 
 # Django
-django==4.2.23
+django==5.0.0
 django-environ==0.9.0
 django-extensions==3.2.1
 werkzeug==2.2.2 # required by django-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ crispy-bootstrap4==2025.6
 django-simple-history==3.10.1
 django-treebeard==4.7.1
 django-celery-beat==2.8.1
-django-redis==6.0.0   #TODO:
+django-redis==6.0.0
 django-filter==25.1
 django-pivot==1.10.0
 djangorestframework==3.16.0
@@ -33,8 +33,8 @@ django-cors-headers==4.7.0
 # Celery/ Redis
 amqp==5.3.1
 celery==5.5.3
-redis==4.3.4    #TODO:
-hiredis==2.0.0  #TODO:
+redis==6.2.0
+hiredis==3.2.1
 flower==2.0.1
 
 # Database

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,10 +1,10 @@
 -r ./base.txt
 
-sphinx==5.3.0
-sphinx-autobuild==2021.3.14
-furo==2022.12.7
-myst-parser==0.18.1
-sphinx_design==0.3.0
-sphinx-copybutton==0.5.1
+sphinx==8.2.3
+sphinx-autobuild==2024.10.3
+furo==2024.8.6
+myst-parser==4.0.1
+sphinx_design==0.6.1
+sphinx-copybutton==0.5.2
 linuxdoc==20240924
-sphinx-toolbox==3.4.0
+sphinx-toolbox==4.0.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,5 +6,5 @@ furo==2022.12.7
 myst-parser==0.18.1
 sphinx_design==0.3.0
 sphinx-copybutton==0.5.1
-linuxdoc==20221127
+linuxdoc==20240924
 sphinx-toolbox==3.4.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,7 +2,7 @@
 
 # Testing/ Linting
 # ensure parity w/ version in .pre-commit-config.yaml
-ruff==0.12.0
+ruff==0.12.1
 black==25.1.0
 # ---
 pytest==8.4.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -10,9 +10,9 @@ pytest-django==4.5.2
 # mypy==0.991
 # django-stubs==1.13.1
 coverage==7.0.1
-django-coverage-plugin==3.0.0
+django-coverage-plugin==3.1.1
 factory-boy==3.2.1
 selenium==4.13.0
-requests-mock==1.10.0
+requests-mock==1.12.1
 pre-commit==2.20.0
 time-machine==2.8.2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,17 +2,15 @@
 
 # Testing/ Linting
 # ensure parity w/ version in .pre-commit-config.yaml
-ruff==0.11.12   
-# black==25.1.0   # not available for python3.8
+ruff==0.12.0
+black==25.1.0
 # ---
-pytest==7.2.0
-pytest-django==4.5.2
-# mypy==0.991
-# django-stubs==1.13.1
-coverage==7.0.1
+pytest==8.4.1
+pytest-django==4.11.1
+coverage==7.9.1
 django-coverage-plugin==3.1.1
-factory-boy==3.2.1
-selenium==4.13.0
+factory-boy==3.3.3
+selenium==4.33.0
 requests-mock==1.12.1
-pre-commit==2.20.0
-time-machine==2.8.2
+pre-commit==4.2.0
+time-machine==2.16.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,4 +2,4 @@
 
 -r ./base.txt
 
-gunicorn==20.1.0  # https://github.com/benoitc/gunicorn
+gunicorn==23.0.0  # https://github.com/benoitc/gunicorn

--- a/va_explorer/home/tests/test_views.py
+++ b/va_explorer/home/tests/test_views.py
@@ -20,7 +20,6 @@ pytestmark = pytest.mark.django_db
 eastern_tz = gettz("US/Eastern")
 
 
-# FIXME: Test breaks as a result of pandas 1.5 -> 2.0; find out how to fix
 # Hit the trends json endpoint and make sure the counts are correct
 # Use time machine to eliminate variation in retrieving today's date
 @time_machine.travel(dt.datetime(2021, 10, 26, 1, 24, tzinfo=eastern_tz))

--- a/va_explorer/home/tests/test_views.py
+++ b/va_explorer/home/tests/test_views.py
@@ -1,19 +1,19 @@
-# import datetime as dt
+import datetime as dt
 import json
 
-# from datetime import date, datetime
+from datetime import date, datetime
 import pytest
 
-# import time_machine
-# from dateutil.relativedelta import relativedelta
+import time_machine
+from pandas.tseries.offsets import DateOffset
 from dateutil.tz import gettz
 from django.test import Client
 
-# from va_explorer.tests.factories import (
-#     CauseCodingIssueFactory,
-#     CauseOfDeathFactory,
-#     VerbalAutopsyFactory,
-# )
+from va_explorer.tests.factories import (
+    CauseCodingIssueFactory,
+    CauseOfDeathFactory,
+    VerbalAutopsyFactory,
+)
 from va_explorer.users.models import User
 
 pytestmark = pytest.mark.django_db
@@ -21,119 +21,121 @@ eastern_tz = gettz("US/Eastern")
 
 
 # FIXME: Test breaks as a result of pandas 1.5 -> 2.0; find out how to fix
-# # Hit the trends json endpoint and make sure the counts are correct
-# # Use time machine to eliminate variation in retrieving today's date
-# @time_machine.travel(dt.datetime(2021, 10, 26, 1, 24, tzinfo=eastern_tz))
-# def test_trends(user: User):
-#     client = Client()
-#     client.force_login(user=user)
+# Hit the trends json endpoint and make sure the counts are correct
+# Use time machine to eliminate variation in retrieving today's date
+@time_machine.travel(dt.datetime(2021, 10, 26, 1, 24, tzinfo=eastern_tz))
+def test_trends(user: User):
+    client = Client()
+    client.force_login(user=user)
 
-#     today = date.today()
+    today = date.today()
 
-#     # Other interview dates
-#     today_minus_one_month = datetime.now() - relativedelta(months=1)
-#     today_minus_six_months = datetime.now() - relativedelta(months=6)
-#     today_minus_one_year = datetime.now() - relativedelta(months=12)
 
-#     # VAs collected today = 2
-#     coded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
-#     uncoded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
-#     # VAs collected at other points in time = 3
-#     VerbalAutopsyFactory.create(
-#         Id10012=today_minus_one_month, Id10023=today_minus_one_month
-#     )
-#     VerbalAutopsyFactory.create(
-#         Id10012=today_minus_six_months, Id10023=today_minus_six_months
-#     )
-#     VerbalAutopsyFactory.create(
-#         Id10012=today_minus_one_year, Id10023=today_minus_one_year
-#     )
+    # Other interview dates
+    today_minus_one_month = datetime.now() - DateOffset(months=1)
+    today_minus_six_months = datetime.now() - DateOffset(months=6)
+    today_minus_one_year = datetime.now() - DateOffset(months=12)
 
-#     CauseOfDeathFactory.create(cause="Indeterminate", verbalautopsy=coded_va)
-#     CauseCodingIssueFactory.create(verbalautopsy=coded_va, severity="error")
+    # VAs collected today = 2
+    coded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
+    uncoded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
+    # VAs collected at other points in time = 3
+    VerbalAutopsyFactory.create(
+        Id10012=today_minus_one_month, Id10023=today_minus_one_month
+    )
+    VerbalAutopsyFactory.create(
+        Id10012=today_minus_six_months, Id10023=today_minus_six_months
+    )
+    VerbalAutopsyFactory.create(
+        Id10012=today_minus_one_year, Id10023=today_minus_one_year
+    )
 
-#     response = client.get("/trends", follow=True)
-#     assert response.status_code == 200
+    CauseOfDeathFactory.create(cause="Indeterminate", verbalautopsy=coded_va)
+    CauseCodingIssueFactory.create(verbalautopsy=coded_va, severity="error")
 
-#     json_data = json.loads(response.content)
-#     va_table_data = json_data["vaTable"]
+    response = client.get("/trends", follow=True)
+    assert response.status_code == 200
 
-#     # Check that trends counts are correct
-#     assert va_table_data["collected"]["24"] == 2
-#     assert va_table_data["collected"]["1 week"] == 2
-#     assert va_table_data["collected"]["1 month"] == 3
-#     assert va_table_data["collected"]["Overall"] == 5
+    json_data = json.loads(response.content)
+    va_table_data = json_data["vaTable"]
+    print(va_table_data)
 
-#     assert va_table_data["coded"]["24"] == 1
-#     assert va_table_data["coded"]["1 week"] == 1
-#     assert va_table_data["coded"]["1 month"] == 1
-#     assert va_table_data["coded"]["Overall"] == 1
+    # Check that trends counts are correct
+    assert va_table_data["collected"]["24"] == 2
+    assert va_table_data["collected"]["1 week"] == 2
+    assert va_table_data["collected"]["1 month"] == 3
+    assert va_table_data["collected"]["Overall"] == 5
 
-#     assert va_table_data["uncoded"]["24"] == 1
-#     assert va_table_data["uncoded"]["1 week"] == 1
-#     assert va_table_data["uncoded"]["1 month"] == 2
-#     assert va_table_data["uncoded"]["Overall"] == 4
+    assert va_table_data["coded"]["24"] == 1
+    assert va_table_data["coded"]["1 week"] == 1
+    assert va_table_data["coded"]["1 month"] == 1
+    assert va_table_data["coded"]["Overall"] == 1
 
-#     # Check that the underlying graph data are correct
-#     # Graphs do not show VAs collected in the current month
-#     # Thus, the collected VAs were in: October, April, and September
-#     assert json_data["graphs"]["collected"]["y"] == [
-#         1.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         1.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         1.0,
-#     ]
-#     # Graphs do not show VAs coded in the current month
-#     # Thus, there are no coded VAs in the time period in question
-#     assert json_data["graphs"]["coded"]["y"] == [
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#     ]
-#     # Graphs do not show VAs uncoded in the current month
-#     # Thus, the uncoded VAs were in: October, April, and September
-#     assert json_data["graphs"]["uncoded"]["y"] == [
-#         1.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         1.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         0.0,
-#         1.0,
-#     ]
+    assert va_table_data["uncoded"]["24"] == 1
+    assert va_table_data["uncoded"]["1 week"] == 1
+    assert va_table_data["uncoded"]["1 month"] == 2
+    assert va_table_data["uncoded"]["Overall"] == 4
 
-#     # VAs in issue list includes VAs with no cause in Cause of Death
-#     assert len(json_data["issueList"]) == 4
-#     assert uncoded_va.Id10017 in json_data["issueList"][0]["deceased"]
-#     assert json_data["additionalIssues"] == 0
-#     # VAs in indeterminate COD list includes VAs with indeterminate COD
-#     assert len(json_data["indeterminateCodList"]) == 1
-#     assert json_data["indeterminateCodList"][0]["id"] == coded_va.id
-#     assert json_data["additionalIndeterminateCods"] == 0
+    # Check that the underlying graph data are correct
+    # Graphs do not show VAs collected in the current month
+    # Thus, the collected VAs were in: October, April, and September
+    assert json_data["graphs"]["collected"]["y"] == [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+    # Graphs do not show VAs coded in the current month
+    # Thus, there are no coded VAs in the time period in question
+    assert json_data["graphs"]["coded"]["y"] == [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ]
+    # Graphs do not show VAs uncoded in the current month
+    # Thus, the uncoded VAs were in: October, April, and September
+    assert json_data["graphs"]["uncoded"]["y"] == [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
 
-#     assert json_data["isFieldWorker"] is False
+    # VAs in issue list includes VAs with no cause in Cause of Death
+    assert len(json_data["issueList"]) == 4
+    assert uncoded_va.Id10017 in json_data["issueList"][0]["deceased"]
+    assert json_data["additionalIssues"] == 0
+    # VAs in indeterminate COD list includes VAs with indeterminate COD
+    assert len(json_data["indeterminateCodList"]) == 1
+    assert json_data["indeterminateCodList"][0]["id"] == coded_va.id
+    assert json_data["additionalIndeterminateCods"] == 0
+
+    assert json_data["isFieldWorker"] is False
 
 
 # Hit the trends json endpoint and make sure the counts are correct

--- a/va_explorer/home/tests/test_views.py
+++ b/va_explorer/home/tests/test_views.py
@@ -1,13 +1,12 @@
 import datetime as dt
 import json
-
 from datetime import date, datetime
-import pytest
 
+import pytest
 import time_machine
-from pandas.tseries.offsets import DateOffset
 from dateutil.tz import gettz
 from django.test import Client
+from pandas.tseries.offsets import DateOffset
 
 from va_explorer.tests.factories import (
     CauseCodingIssueFactory,
@@ -28,7 +27,6 @@ def test_trends(user: User):
     client.force_login(user=user)
 
     today = date.today()
-
 
     # Other interview dates
     today_minus_one_month = datetime.now() - DateOffset(months=1)
@@ -57,7 +55,6 @@ def test_trends(user: User):
 
     json_data = json.loads(response.content)
     va_table_data = json_data["vaTable"]
-    print(va_table_data)
 
     # Check that trends counts are correct
     assert va_table_data["collected"]["24"] == 2

--- a/va_explorer/home/tests/test_views.py
+++ b/va_explorer/home/tests/test_views.py
@@ -1,137 +1,139 @@
-import datetime as dt
+# import datetime as dt
 import json
-from datetime import date, datetime
 
+# from datetime import date, datetime
 import pytest
-import time_machine
-from dateutil.relativedelta import relativedelta
+
+# import time_machine
+# from dateutil.relativedelta import relativedelta
 from dateutil.tz import gettz
 from django.test import Client
 
-from va_explorer.tests.factories import (
-    CauseCodingIssueFactory,
-    CauseOfDeathFactory,
-    VerbalAutopsyFactory,
-)
+# from va_explorer.tests.factories import (
+#     CauseCodingIssueFactory,
+#     CauseOfDeathFactory,
+#     VerbalAutopsyFactory,
+# )
 from va_explorer.users.models import User
 
 pytestmark = pytest.mark.django_db
 eastern_tz = gettz("US/Eastern")
 
 
-# Hit the trends json endpoint and make sure the counts are correct
-# Use time machine to eliminate variation in retrieving today's date
-@time_machine.travel(dt.datetime(2021, 10, 26, 1, 24, tzinfo=eastern_tz))
-def test_trends(user: User):
-    client = Client()
-    client.force_login(user=user)
+# FIXME: Test breaks as a result of pandas 1.5 -> 2.0; find out how to fix
+# # Hit the trends json endpoint and make sure the counts are correct
+# # Use time machine to eliminate variation in retrieving today's date
+# @time_machine.travel(dt.datetime(2021, 10, 26, 1, 24, tzinfo=eastern_tz))
+# def test_trends(user: User):
+#     client = Client()
+#     client.force_login(user=user)
 
-    today = date.today()
+#     today = date.today()
 
-    # Other interview dates
-    today_minus_one_month = datetime.now() - relativedelta(months=1)
-    today_minus_six_months = datetime.now() - relativedelta(months=6)
-    today_minus_one_year = datetime.now() - relativedelta(months=12)
+#     # Other interview dates
+#     today_minus_one_month = datetime.now() - relativedelta(months=1)
+#     today_minus_six_months = datetime.now() - relativedelta(months=6)
+#     today_minus_one_year = datetime.now() - relativedelta(months=12)
 
-    # VAs collected today = 2
-    coded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
-    uncoded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
-    # VAs collected at other points in time = 3
-    VerbalAutopsyFactory.create(
-        Id10012=today_minus_one_month, Id10023=today_minus_one_month
-    )
-    VerbalAutopsyFactory.create(
-        Id10012=today_minus_six_months, Id10023=today_minus_six_months
-    )
-    VerbalAutopsyFactory.create(
-        Id10012=today_minus_one_year, Id10023=today_minus_one_year
-    )
+#     # VAs collected today = 2
+#     coded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
+#     uncoded_va = VerbalAutopsyFactory.create(Id10012=today, Id10023=today)
+#     # VAs collected at other points in time = 3
+#     VerbalAutopsyFactory.create(
+#         Id10012=today_minus_one_month, Id10023=today_minus_one_month
+#     )
+#     VerbalAutopsyFactory.create(
+#         Id10012=today_minus_six_months, Id10023=today_minus_six_months
+#     )
+#     VerbalAutopsyFactory.create(
+#         Id10012=today_minus_one_year, Id10023=today_minus_one_year
+#     )
 
-    CauseOfDeathFactory.create(cause="Indeterminate", verbalautopsy=coded_va)
-    CauseCodingIssueFactory.create(verbalautopsy=coded_va, severity="error")
+#     CauseOfDeathFactory.create(cause="Indeterminate", verbalautopsy=coded_va)
+#     CauseCodingIssueFactory.create(verbalautopsy=coded_va, severity="error")
 
-    response = client.get("/trends", follow=True)
-    assert response.status_code == 200
+#     response = client.get("/trends", follow=True)
+#     assert response.status_code == 200
 
-    json_data = json.loads(response.content)
-    va_table_data = json_data["vaTable"]
+#     json_data = json.loads(response.content)
+#     va_table_data = json_data["vaTable"]
 
-    # Check that trends counts are correct
-    assert va_table_data["collected"]["24"] == 2
-    assert va_table_data["collected"]["1 week"] == 2
-    assert va_table_data["collected"]["1 month"] == 3
-    assert va_table_data["collected"]["Overall"] == 5
+#     # Check that trends counts are correct
+#     assert va_table_data["collected"]["24"] == 2
+#     assert va_table_data["collected"]["1 week"] == 2
+#     assert va_table_data["collected"]["1 month"] == 3
+#     assert va_table_data["collected"]["Overall"] == 5
 
-    assert va_table_data["coded"]["24"] == 1
-    assert va_table_data["coded"]["1 week"] == 1
-    assert va_table_data["coded"]["1 month"] == 1
-    assert va_table_data["coded"]["Overall"] == 1
+#     assert va_table_data["coded"]["24"] == 1
+#     assert va_table_data["coded"]["1 week"] == 1
+#     assert va_table_data["coded"]["1 month"] == 1
+#     assert va_table_data["coded"]["Overall"] == 1
 
-    assert va_table_data["uncoded"]["24"] == 1
-    assert va_table_data["uncoded"]["1 week"] == 1
-    assert va_table_data["uncoded"]["1 month"] == 2
-    assert va_table_data["uncoded"]["Overall"] == 4
+#     assert va_table_data["uncoded"]["24"] == 1
+#     assert va_table_data["uncoded"]["1 week"] == 1
+#     assert va_table_data["uncoded"]["1 month"] == 2
+#     assert va_table_data["uncoded"]["Overall"] == 4
 
-    # Check that the underlying graph data are correct
-    # Graphs do not show VAs collected in the current month
-    # Thus, the collected VAs were in: October, April, and September
-    assert json_data["graphs"]["collected"]["y"] == [
-        1.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    ]
-    # Graphs do not show VAs coded in the current month
-    # Thus, there are no coded VAs in the time period in question
-    assert json_data["graphs"]["coded"]["y"] == [
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-    ]
-    # Graphs do not show VAs uncoded in the current month
-    # Thus, the uncoded VAs were in: October, April, and September
-    assert json_data["graphs"]["uncoded"]["y"] == [
-        1.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    ]
+#     # Check that the underlying graph data are correct
+#     # Graphs do not show VAs collected in the current month
+#     # Thus, the collected VAs were in: October, April, and September
+#     assert json_data["graphs"]["collected"]["y"] == [
+#         1.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         1.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         1.0,
+#     ]
+#     # Graphs do not show VAs coded in the current month
+#     # Thus, there are no coded VAs in the time period in question
+#     assert json_data["graphs"]["coded"]["y"] == [
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#     ]
+#     # Graphs do not show VAs uncoded in the current month
+#     # Thus, the uncoded VAs were in: October, April, and September
+#     assert json_data["graphs"]["uncoded"]["y"] == [
+#         1.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         1.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         0.0,
+#         1.0,
+#     ]
 
-    # VAs in issue list includes VAs with no cause in Cause of Death
-    assert len(json_data["issueList"]) == 4
-    assert uncoded_va.Id10017 in json_data["issueList"][0]["deceased"]
-    assert json_data["additionalIssues"] == 0
-    # VAs in indeterminate COD list includes VAs with indeterminate COD
-    assert len(json_data["indeterminateCodList"]) == 1
-    assert json_data["indeterminateCodList"][0]["id"] == coded_va.id
-    assert json_data["additionalIndeterminateCods"] == 0
+#     # VAs in issue list includes VAs with no cause in Cause of Death
+#     assert len(json_data["issueList"]) == 4
+#     assert uncoded_va.Id10017 in json_data["issueList"][0]["deceased"]
+#     assert json_data["additionalIssues"] == 0
+#     # VAs in indeterminate COD list includes VAs with indeterminate COD
+#     assert len(json_data["indeterminateCodList"]) == 1
+#     assert json_data["indeterminateCodList"][0]["id"] == coded_va.id
+#     assert json_data["additionalIndeterminateCods"] == 0
 
-    assert json_data["isFieldWorker"] is False
+#     assert json_data["isFieldWorker"] is False
 
 
 # Hit the trends json endpoint and make sure the counts are correct

--- a/va_explorer/templates/base.html
+++ b/va_explorer/templates/base.html
@@ -52,7 +52,6 @@
   <script src="{% static 'vendor/popper-1.14.3/popper.min.js' %}"></script>
   <script src="{% static 'vendor/bootstrap-4.3.1/bootstrap.min.js' %}"></script>
   <script src="{% static 'js/project.js' %}"></script>
-  <script src="{% static 'js/logging_event_handlers.js' %}"></script>
 
   {% block page_scripts %}{% endblock %}
 

--- a/va_explorer/tests/factories.py
+++ b/va_explorer/tests/factories.py
@@ -24,6 +24,7 @@ class PermissionFactory(DjangoModelFactory):
 class GroupFactory(DjangoModelFactory):
     class Meta:
         model = models.Group
+        skip_postgeneration_save = True
 
     name = Sequence(lambda n: f"Group #{n}")
 
@@ -33,10 +34,11 @@ class GroupFactory(DjangoModelFactory):
             # Simple build, do nothing.
             return
 
-        if extracted:
+        if create and extracted:
             # A list of groups were passed in, use them
             for permission in extracted:
                 self.permissions.add(permission)
+            self.save()
 
 
 class LocationFactory(DjangoModelFactory):
@@ -87,6 +89,7 @@ class CauseOfDeathFactory(DjangoModelFactory):
 class UserFactory(DjangoModelFactory):
     class Meta:
         model = User
+        skip_postgeneration_save = True
 
     email = Faker("email")
     name = Faker("name")
@@ -99,10 +102,11 @@ class UserFactory(DjangoModelFactory):
             # Simple build, do nothing.
             return
 
-        if extracted:
+        if create and extracted:
             # A list of groups were passed in, use them
             for group in extracted:
                 self.groups.add(group)
+            self.save()
 
     @factory.post_generation
     def location_restrictions(self, create, extracted, *kwargs):
@@ -110,10 +114,11 @@ class UserFactory(DjangoModelFactory):
             # Simple build, do nothing.
             return
 
-        if extracted:
+        if create and extracted:
             # A list of locations were passed in, use them
             for location in extracted:
                 self.location_restrictions.add(location)
+            self.save()
 
 
 class NewUserFactory(UserFactory):

--- a/va_explorer/users/forms.py
+++ b/va_explorer/users/forms.py
@@ -6,7 +6,7 @@ from allauth.account.forms import (
 )
 from django import forms
 from django.contrib.auth import get_user_model, password_validation
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import BaseUserCreationForm
 from django.contrib.auth.models import Group
 from django.db.models import Q
 from django.forms import (
@@ -169,15 +169,15 @@ class UserCommonFields(forms.ModelForm):
     )
 
 
-class ExtendedUserCreationForm(UserCommonFields, UserCreationForm):
+class ExtendedUserCreationForm(UserCommonFields, BaseUserCreationForm):
     """
-    Extends the built in UserCreationForm in several ways:
+    Extends the built in BaseUserCreationForm in several ways:
 
     * Name field is added.
     * Group model from django.contrib.auth.models is represented as a ModelChoiceField
     * Non-model field geographic_access added to toggle between national and
       location-specific access
-    * Data not saved by the default behavior of UserCreationForm is saved.
+    * Data not saved by the default behavior of BaseUserCreationForm is saved.
     """
 
     password1 = None
@@ -203,7 +203,7 @@ class ExtendedUserCreationForm(UserCommonFields, UserCreationForm):
         """
         self.request = kwargs.pop("request", None)
 
-        super(UserCreationForm, self).__init__(*args, **kwargs)
+        super(BaseUserCreationForm, self).__init__(*args, **kwargs)
 
         self.fields["group"].label = "Role"
 
@@ -211,7 +211,7 @@ class ExtendedUserCreationForm(UserCommonFields, UserCreationForm):
         """
         Normal cleanup
         """
-        cleaned_data = super(UserCreationForm, self).clean(*args, **kwargs)
+        cleaned_data = super(BaseUserCreationForm, self).clean(*args, **kwargs)
 
         if "geographic_access" and "group" in cleaned_data:
             location_restrictions = get_location_restrictions(cleaned_data)
@@ -233,7 +233,7 @@ class ExtendedUserCreationForm(UserCommonFields, UserCreationForm):
 
         Saves the location and group after the user object is saved.
         """
-        user = super(UserCreationForm, self).save(commit)
+        user = super(BaseUserCreationForm, self).save(commit)
         if user:
             user.email = self.cleaned_data["email"]
             user.name = self.cleaned_data["name"]
@@ -276,7 +276,7 @@ class ExtendedUserCreationForm(UserCommonFields, UserCreationForm):
 
 class UserUpdateForm(UserCommonFields, forms.ModelForm):
     """
-    Similar to UserCreationForm but adds is_active field to allow an administrator
+    Similar to BaseUserCreationForm but adds is_active field to allow an administrator
     to mark a user account as inactive
     """
 

--- a/va_explorer/va_data_management/forms.py
+++ b/va_explorer/va_data_management/forms.py
@@ -23,7 +23,7 @@ class VerbalAutopsyForm(forms.ModelForm):
             )
         for form_field in FORM_FIELDS["checkbox"]:
             widgets[form_field] = MultiSelectFormField(
-                flat_choices=FORM_FIELDS["checkbox"][form_field]
+                choices=FORM_FIELDS["checkbox"][form_field]
             ).widget
             widgets[form_field].attrs = {"class": "va-check"}
         for form_field in FORM_FIELDS["dropdown"]:

--- a/va_explorer/va_data_management/utils/date_parsing.py
+++ b/va_explorer/va_data_management/utils/date_parsing.py
@@ -55,7 +55,9 @@ def to_dt(dates, utc=True):
     if isinstance(dates, list):
         dates = pd.Series(dates)
     return pd.to_datetime(
-        pd.to_datetime(dates, errors="coerce", utc=utc, format="mixed").dt.date, format="mixed", errors="coerce"
+        pd.to_datetime(dates, errors="coerce", utc=utc, format="mixed").dt.date,
+        format="mixed",
+        errors="coerce",
     )
 
 

--- a/va_explorer/va_data_management/utils/date_parsing.py
+++ b/va_explorer/va_data_management/utils/date_parsing.py
@@ -55,7 +55,7 @@ def to_dt(dates, utc=True):
     if isinstance(dates, list):
         dates = pd.Series(dates)
     return pd.to_datetime(
-        pd.to_datetime(dates, errors="coerce", utc=utc).dt.date, errors="coerce"
+        pd.to_datetime(dates, errors="coerce", utc=utc, format="mixed").dt.date, format="mixed", errors="coerce"
     )
 
 

--- a/va_explorer/va_data_management/utils/location_assignment.py
+++ b/va_explorer/va_data_management/utils/location_assignment.py
@@ -22,7 +22,7 @@ def assign_va_location(va, location_mapper=None, location_fields=None):
                 .only("name", "key")
                 .values_list("key", "name")
             )
-        db_location_name = location_mapper.get(raw_location, None)
+        db_location_name = location_mapper.get(raw_location)
         # if matching db location, retrieve it. Otherwise, record location as unknown
         if db_location_name:
             # TODO: make this more generic to other location hierarchies

--- a/va_explorer/va_data_management/utils/multi_select.py
+++ b/va_explorer/va_data_management/utils/multi_select.py
@@ -3,33 +3,21 @@ from django.core import exceptions
 from django.db import models
 from django.utils.text import capfirst
 
-# This is a port of django-multiselectfield: https://pypi.org/project/django-multiselectfield/
-# The relevant logic has been extracted from django-multiselectfield and included
-# in this module. MultiSelectField has been updated to subclass models.TextField
-# instead of models.CharField
-
-
-class MSFList(list):
-    def __init__(self, choices, *args, **kwargs):
-        self.choices = choices
-        super().__init__(*args, **kwargs)
-
-    def __str__(msgl):
-        msg_list = [
-            msgl.choices.get(int(i)) if i.isdigit() else msgl.choices.get(i)
-            for i in msgl
-        ]
-        return ", ".join([str(s) for s in msg_list])
-
 
 class MultiSelectFormField(forms.MultipleChoiceField):
+    """
+    This is a port of django-multiselectfield: https://pypi.org/project/django-multiselectfield/
+    The relevant logic has been extracted from django-multiselectfield and included
+    in this module. MultiSelectField has been updated to subclass models.TextField
+    instead of models.CharField. Last updated django-multiselectfield==1.0.1
+    """
+
     widget = forms.CheckboxSelectMultiple
 
     def __init__(self, *args, **kwargs):
         self.min_choices = kwargs.pop("min_choices", None)
         self.max_choices = kwargs.pop("max_choices", None)
         self.max_length = kwargs.pop("max_length", None)
-        self.flat_choices = kwargs.pop("flat_choices")
         self.widget.attrs = {"class": "va-check"}
         super().__init__(*args, **kwargs)
         # TODO: Uncomment if supporting max_length, max_choices, min_choices
@@ -40,23 +28,6 @@ class MultiSelectFormField(forms.MultipleChoiceField):
         # if self.min_choices is not None:
         #     self.validators.append(MinChoicesValidator(self.min_choices))
 
-    def to_python(self, value):
-        return MSFList(dict(self.flat_choices), super().to_python(value))
-
-
-def add_metaclass(metaclass):
-    """Class decorator for creating a class with a metaclass."""
-
-    def wrapper(cls):
-        orig_vars = cls.__dict__.copy()
-        orig_vars.pop("__dict__", None)
-        orig_vars.pop("__weakref__", None)
-        for slots_var in orig_vars.get("__slots__", ()):
-            orig_vars.pop(slots_var)
-        return metaclass(cls.__name__, cls.__bases__, orig_vars)
-
-    return wrapper
-
 
 class MultiSelectField(models.TextField):
     """Choice values can not contain commas."""
@@ -65,97 +36,82 @@ class MultiSelectField(models.TextField):
         self.min_choices = kwargs.pop("min_choices", None)
         self.max_choices = kwargs.pop("max_choices", None)
         super().__init__(*args, **kwargs)
-
-    def _get_flatchoices(self):
-        flat_choices = super()._get_flatchoices()
-
-        class MSFFlatchoices(list):
-            # Used to trick django.contrib.admin.utils.display_for_field into
-            # not treating the list of values as a dictionary key (which errors
-            # out)
-            def __bool__(self):
-                return False
-
-            __nonzero__ = __bool__
-
-        return MSFFlatchoices(flat_choices)
-
-    flatchoices = property(_get_flatchoices)
-
-    def get_choices_default(self):
-        return self.get_choices(include_blank=False)
-
-    def get_choices_selected(self, arr_choices):
-        named_groups = arr_choices and isinstance(arr_choices[0][1], (list, tuple))
-        choices_selected = []
-        if named_groups:
-            for choice_group_selected in arr_choices:
-                for choice_selected in choice_group_selected[1]:
-                    choices_selected.append(str(choice_selected[0]))
-        else:
-            for choice_selected in arr_choices:
-                choices_selected.append(str(choice_selected[0]))
-        return choices_selected
+        # TODO: Uncomment if supporting max_length, max_choices, min_choices
+        # self.max_length = get_max_length(self.choices, self.max_length)
+        # if VERSION <= (4, 1):
+        #     self.validators[0] = MaxValueMultiFieldValidator(self.max_length)
+        # else:
+        #     self.validators.append(MaxValueMultiFieldValidator(self.max_length))
+        # if self.min_choices is not None:
+        #     self.validators.append(MinChoicesValidator(self.min_choices))
+        # if self.max_choices is not None:
+        #     self.validators.append(MaxChoicesValidator(self.max_choices))
 
     def value_to_string(self, obj):
-        try:
-            value = self._get_val_from_obj(obj)
-        except AttributeError:
-            value = super().value_from_object(obj)
+        value = super().value_from_object(obj)
         return self.get_prep_value(value)
 
     def validate(self, value, model_instance):
-        arr_choices = self.get_choices_selected(self.get_choices_default())
-        for opt_select in value:
-            if opt_select not in arr_choices:
-                raise exceptions.ValidationError(
-                    self.error_messages["invalid_choice"] % {"value": value}
-                )
+        if not self.editable:
+            # Skip validation for non-editable fields.
+            return
+        if self.choices is not None and value not in self.empty_values:
+            arr_choices = dict(self.flatchoices).keys()
+            for opt_select in value:
+                if opt_select not in arr_choices:
+                    raise exceptions.ValidationError(
+                        self.error_messages["invalid_choice"] % {"value": value}
+                    )
 
-    def get_default(self):
-        default = super().get_default()
-        if isinstance(default, int):
-            default = str(default)
-        return default
+        if value is None and not self.null:
+            raise exceptions.ValidationError(self.error_messages["null"], code="null")
+
+        if not self.blank and value in self.empty_values:
+            raise exceptions.ValidationError(self.error_messages["blank"], code="blank")
 
     def formfield(self, **kwargs):
+        if isinstance(kwargs.get("form_class"), MultiSelectFormField):
+            return kwargs.get("form_class")
+
         defaults = {
             "required": not self.blank,
             "label": capfirst(self.verbose_name),
             "help_text": self.help_text,
             "choices": self.choices,
-            "flat_choices": self.flatchoices,
             "max_length": self.max_length,
+            "min_choices": self.min_choices,
             "max_choices": self.max_choices,
         }
         if self.has_default():
             defaults["initial"] = self.get_default()
+
         defaults.update(kwargs)
-        return MultiSelectFormField(**defaults)
+        form_class = (
+            defaults.pop("form_class", MultiSelectFormField) or MultiSelectFormField
+        )
+
+        return form_class(**defaults)
 
     def get_prep_value(self, value):
-        if type(value) is MSFList:
-            return ",".join(map(str, value))
-        else:
+        if isinstance(value, str):
+            return value
+        if value is None:
+            return ""
+        # It is a list
+        try:
+            return ",".join(value)
+        # LOCAL FORK CUSTOM LOGIC
+        except TypeError:
+            # Handle cases where value is not iterable (e.g., nan or invalid types)
             return ""
 
-    def get_db_prep_value(self, value, connection, prepared=False):
-        if not prepared and not isinstance(value, str):
-            value = self.get_prep_value(value)
-        return value
-
     def to_python(self, value):
-        choices = dict(self.flatchoices)
-
-        if value:
-            if isinstance(value, list):
-                return value
-            elif isinstance(value, str):
-                value_list = (x.strip() for x in value.replace(",", ",").split(","))
-                return MSFList(choices, value_list)
-            elif isinstance(value, (set, dict)):
-                return MSFList(choices, list(value))
-        return MSFList(choices, [])
+        if isinstance(value, list):
+            return value
+        if not value:
+            return []
+        # It is a string
+        return value.split(",")
 
     def from_db_value(self, value, expression, connection):
         if value is None:
@@ -168,16 +124,11 @@ class MultiSelectField(models.TextField):
 
             def get_list(obj):
                 fieldname = name
-                choicedict = dict(self.choices)
+                choicedict = dict(self.flatchoices)
                 display = []
                 if getattr(obj, fieldname):
                     for value in getattr(obj, fieldname):
-                        item_display = choicedict.get(value)
-                        if item_display is None:
-                            try:
-                                item_display = choicedict.get(int(value), value)
-                            except (ValueError, TypeError):
-                                item_display = value
+                        item_display = choicedict.get(value, value)
                         display.append(str(item_display))
                 return display
 


### PR DESCRIPTION
## Summary
This MR modernizes VA Explorer by bumping the underlying target python versions, upgrading requirements.txt packages to their latest versions, and using newer docker images to match.

Along the way, tweaks have been made to remedy any breaking/non-backwards compatible changes introduced by migrating between major versions of python, packages, or docker images.

### Adds
- new `crispy-bootstrap4` dependency to comply with major version bump on `django-crispy-forms` migration instructions
- `skip_postgeneration_save logic` to `factories.py` classes to fix deprecation warning introduced by `factory-boy` bump
- required allauth AccountMiddleware added to handle changes introduced by django-allauth 0.56.0

### Changes
- updates project (unofficial) "release" version from 0.1.0 to 0.2.0 to indicate change via existing specifiers
- moves project's supported python versions from *[3.8, 3.9, 3.10]* to *[3.11, 3.12, 3.13]* targeting 3.12
- brings app's main Django dependency from 4.1 to 5.2
  - `BaseUserCreationForm` now used in >=4.2 instead of `UserCreationForm` used in <=4.1
  - `multi_select.py` monkeypatch updated to reflect latest version of django-multiselect source
- beyond Django, bumps all packages in `requirements/base.py` to their latest versions
  - fixes issue introduced by pandas version bump from 1.5 to 2.0 related to datetimes, timedeltas, and parse_date
- bumps all packages in `requirements/local.txt` to their latest versions
- bumps all packages in `requirements/docs.txt` to their latest versions
- bumps all packages in `requirements/production.txt` to their latest versions
- updates main docker image from base `python:3.8-slim` to `python:3.12-slim-bookworm`
- migrates postgres base image from 13.2 to 17.5
- moves redis base image from 5.0 to 8

### Removes
- cleans up legacy reference to `logging_event_handlers.js` that no longer exists

## Testing Suggestions
1. Confirm all unit tests pass via `pytest`
1. Run the app locally via `runserver` management command. (Create a superuser to login with if needed via `seed_admin_user` management command) (ensure your local install of postgres matches 17.5 as well)
1. Login to app and confirm all functionality still works as expected since the only changes are underlying package bumps.
1. Run the app via `docker compose up -d`
1. Login to docker instance of app and confirm all functionality still works as expected

To get a useful seeded environment both locally and in docker, use these commands:
```
# Locally
./manage.py seed_admin_user test@example.com
./manage.py load_locations ./locations-file.csv
./manage.py load_va_csv ./example_vas.csv
docker compose up -d pycrossva interva5
./manage.py run_coding_algorithms

# Docker
docker cp ./locations-file.csv va_explorer_django:/app/locations-file.csv
docker cp ./example_vas.csv va_explorer_django:/app/example_vas.csv
docker exec -it va_explorer_django bash
  λ ./manage.py seed_admin_user test@example.com
  λ ./manage.py load_locations ./locations-file.csv
  λ ./manage.py load_va_csv ./example_vas.csv
  λ ./manage.py run_coding_algorithms
  λ exit
docker compose logs -f
```

